### PR TITLE
PV-82 Testing foundation

### DIFF
--- a/parking_permits_app/tests.py
+++ b/parking_permits_app/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/parking_permits_app/tests/tests.py
+++ b/parking_permits_app/tests/tests.py
@@ -1,0 +1,3 @@
+def test_database_connection_works_in_tests(django_user_model):
+    django_user_model.objects.create_user(username='banana')
+    assert django_user_model.objects.get(username='banana')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+
+DJANGO_SETTINGS_MODULE = project.settings
+python_files = tests.py test_*.py *_tests.py
+addopts = --verbose --reuse-db

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,5 @@
 -c requirements.txt # Constrained by requirements.txt
 
 pip-tools==6.0.1                              # package management tool
+pytest-django==4.2.0                          # test runner integration with Django
+pytest==6.2.3                                 # test runner

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,14 +4,34 @@
 #
 #    pip-compile requirements-dev.in
 #
+attrs==20.3.0
+    # via pytest
 click==7.1.2
     # via pip-tools
+iniconfig==1.1.1
+    # via pytest
+packaging==20.9
+    # via pytest
 pep517==0.10.0
     # via pip-tools
 pip-tools==6.0.1
     # via -r requirements-dev.in
+pluggy==0.13.1
+    # via pytest
+py==1.10.0
+    # via pytest
+pyparsing==2.4.7
+    # via packaging
+pytest-django==4.2.0
+    # via -r requirements-dev.in
+pytest==6.2.3
+    # via
+    #   -r requirements-dev.in
+    #   pytest-django
 toml==0.10.2
-    # via pep517
+    # via
+    #   pep517
+    #   pytest
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
Some comments 🌙:

* I searched for some time and the only option of having an integrated watching mechanism for running our tests was [pytest-watch](https://github.com/joeyespo/pytest-watch). This is what I have been using in older projects I was part of. However, that project hasn't been maintained for the past 3 years and I don't feel comfortable to add an unmaintained library to this project.
* As an alternative approach, I can write up some documentation later on that whoever wants to run the tests continously can install [entr](https://github.com/eradman/entr) via `brew` or equivalent and then run them with:

```bash
find /directory/to/watch | entr -c docker-compose exec api pytest
```