### PR TITLE
Add Python VirtualEnv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Backend repository for parking permits service developed by City of Helsinki.
 
 Instructions in this README.md are written with an experienced Python developer in mind. For example, "docker-compose up" means you already know what docker and docker-compose are and you already have both installed locally. This helps to keep the README.md concise.
 
-### Setting up local development environment
+### Setting up local development environment with Docker
 
 - Clone the repository
 
@@ -19,6 +19,24 @@ Instructions in this README.md are written with an experienced Python developer 
 - Login to admin interface with `admin` and 🥥
 
 - Done!
+
+### Setting up local development environment with PyEnv and VirtualEnvWrapper
+
+```
+pyenv install -v 3.9.0
+pyenv virtualenv 3.9.0 parking_permits
+pyenv local parking_permits
+pyenv virtualenvwrapper
+```
+
+Install packages
+
+```
+pip install -U pip pip-tools
+pip-compile -U requirements-dev.in
+pip-sync requirements-dev.txt
+```
+
 
 ### Managing project packages
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Install packages
 
 ```
 pip install -U pip pip-tools
+pip-compile -U requirements.in
 pip-compile -U requirements-dev.in
-pip-sync requirements-dev.txt
+pip-sync requirements.txt requirements-dev.txt
 ```
 
 

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,9 +1,9 @@
--r requirements.in # First include all basic requirements
+-c requirements.txt # Constrained by requirements.txt
 
 black==21.4b0                                 # code formatter
-flake8==3.9.1                                 # code linter
+flake8==3.9.1                                  # code linter
 isort==5.8.0                                  # for sorting python imports
-pip-tools==6.0.1                              # package management tool
+pip-tools==6.1.0                              # package management tool
 pre-commit==2.12.1                            # pre-commit hooks package manager
 pytest-django==4.2.0                          # test runner integration with Django
 pytest==6.2.3                                 # test runner

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,4 +1,4 @@
--c requirements.txt # Constrained by requirements.txt
+-r requirements.in # First include all basic requirements
 
 black==21.4b0                                 # code formatter
 flake8==3.9.1                                 # code linter

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,7 +1,7 @@
 -c requirements.txt # Constrained by requirements.txt
 
 black==21.4b0                                 # code formatter
-flake8==3.9.1                                  # code linter
+flake8==3.9.1                                 # code linter
 isort==5.8.0                                  # for sorting python imports
 pip-tools==6.1.0                              # package management tool
 pre-commit==2.12.1                            # pre-commit hooks package manager

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,22 +8,34 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-attrs==20.3.0
+ariadne==0.13.0
+    # via -r requirements.in
+asgiref==3.3.4
+    # via django
+attrs==21.2.0
     # via pytest
 black==21.4b0
     # via -r requirements-dev.in
 cfgv==3.2.0
     # via pre-commit
-click==7.1.2
+click==8.0.0
     # via
     #   black
     #   pip-tools
 distlib==0.3.1
     # via virtualenv
+dj-database-url==0.5.0
+    # via -r requirements.in
+django==3.2
+    # via -r requirements.in
 filelock==3.0.12
     # via virtualenv
 flake8==3.9.1
     # via -r requirements-dev.in
+graphql-core==3.1.5
+    # via ariadne
+gunicorn==20.1.0
+    # via -r requirements.in
 identify==2.2.4
     # via pre-commit
 iniconfig==1.1.1
@@ -48,6 +60,8 @@ pluggy==0.13.1
     # via pytest
 pre-commit==2.12.1
     # via -r requirements-dev.in
+psycopg2-binary==2.8.6
+    # via -r requirements.in
 py==1.10.0
     # via pytest
 pycodestyle==2.7.0
@@ -62,20 +76,31 @@ pytest==6.2.3
     # via
     #   -r requirements-dev.in
     #   pytest-django
+pytz==2021.1
+    # via django
 pyyaml==5.4.1
     # via pre-commit
 regex==2021.4.4
     # via black
-six==1.15.0
+six==1.16.0
     # via virtualenv
+sqlparse==0.4.1
+    # via django
+starlette==0.14.2
+    # via ariadne
 toml==0.10.2
     # via
     #   black
     #   pep517
     #   pre-commit
     #   pytest
-virtualenv==20.4.4
+typing-extensions==3.10.0.0
+    # via ariadne
+virtualenv==20.4.6
     # via pre-commit
+whitenoise==5.2.0
+    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
+# setuptools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,15 +8,11 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-ariadne==0.13.0
-    # via -r requirements.in
-asgiref==3.3.4
-    # via django
 attrs==21.2.0
     # via pytest
 black==21.4b0
     # via -r requirements-dev.in
-cfgv==3.2.0
+cfgv==3.3.0
     # via pre-commit
 click==8.0.0
     # via
@@ -24,18 +20,10 @@ click==8.0.0
     #   pip-tools
 distlib==0.3.1
     # via virtualenv
-dj-database-url==0.5.0
-    # via -r requirements.in
-django==3.2
-    # via -r requirements.in
 filelock==3.0.12
     # via virtualenv
 flake8==3.9.1
     # via -r requirements-dev.in
-graphql-core==3.1.5
-    # via ariadne
-gunicorn==20.1.0
-    # via -r requirements.in
 identify==2.2.4
     # via pre-commit
 iniconfig==1.1.1
@@ -54,14 +42,12 @@ pathspec==0.8.1
     # via black
 pep517==0.10.0
     # via pip-tools
-pip-tools==6.0.1
+pip-tools==6.1.0
     # via -r requirements-dev.in
 pluggy==0.13.1
     # via pytest
 pre-commit==2.12.1
     # via -r requirements-dev.in
-psycopg2-binary==2.8.6
-    # via -r requirements.in
 py==1.10.0
     # via pytest
 pycodestyle==2.7.0
@@ -76,31 +62,20 @@ pytest==6.2.3
     # via
     #   -r requirements-dev.in
     #   pytest-django
-pytz==2021.1
-    # via django
 pyyaml==5.4.1
     # via pre-commit
 regex==2021.4.4
     # via black
 six==1.16.0
     # via virtualenv
-sqlparse==0.4.1
-    # via django
-starlette==0.14.2
-    # via ariadne
 toml==0.10.2
     # via
     #   black
     #   pep517
     #   pre-commit
     #   pytest
-typing-extensions==3.10.0.0
-    # via ariadne
 virtualenv==20.4.6
     # via pre-commit
-whitenoise==5.2.0
-    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
-# setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ dj-database-url==0.5.0
     # via -r requirements.in
 django==3.2
     # via -r requirements.in
-graphql-core==3.1.4
+graphql-core==3.1.5
     # via ariadne
 gunicorn==20.1.0
     # via -r requirements.in
@@ -24,7 +24,7 @@ sqlparse==0.4.1
     # via django
 starlette==0.14.2
     # via ariadne
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via ariadne
 whitenoise==5.2.0
     # via -r requirements.in


### PR DESCRIPTION
This PR will add support and instructions of setting up local development environment with PyEnv and VirtualEnvWrapper.
Also update project requirements so that `requirements-dev.in` would automatically include all requirements from `requirements.in`.