### PR TITLE
Adapt project to use RedHat base image with GDAL 3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ CONN_MAX_AGE=0
 
 # Configures database for Parking Permits using URL style. Format is:
 # postgis://USER:PASSWORD@HOST:PORT/DBNAME
-#DATABASE_URL=postgis://parking_permits_user:parking_permits_password@db:5432/parking_permits_db
+DATABASE_URL=postgis://parking_permits_user:parking_permits_password@parking-permits-database:5432/parking_permits_db
 
 # Jwt token authentication, not yet in use. This settings Specifies
 # the value that must be present in the "aud"-key of the token presented
@@ -119,4 +119,4 @@ DJANGO_SUPERUSER_EMAIL=admin@kool-kids.com
 DJANGO_SUPERUSER_PASSWORD=coconut
 DJANGO_SUPERUSER_USERNAME=admin
 INSTALL_PRECOMMIT=True
-WAIT_FOR_IT_ADDRESS=db:5432
+WAIT_FOR_IT_ADDRESS=parking-permits-database:5432

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,122 @@
+# Parking Permits environment configuration
+# This is supposed to be used only in development, for Django to read it rename it to .env
+# For production use, set environment variables using the facilities
+# of your runtime environment.
+
+# Whether to run Django in debug mode
+# Django setting: DEBUG https://docs.djangoproject.com/en/3.0/ref/settings/#debug
+DEBUG=True
+
+# Level of Django logging. This variable only has effect if DEBUG=True. In that case,
+# all events above the given level will be logged.
+# Django setting: DJANGO_LOG_LEVEL https://docs.djangoproject.com/en/3.0/topics/logging/#examples
+DJANGO_LOG_LEVEL=DEBUG
+
+# Maximum age of Django db connection. The default Django setting closes the db connection after
+# after each request, which may cause slowdown in case the db backend is slow to establish
+# connections.
+CONN_MAX_AGE=0
+
+# Configures database for Parking Permits using URL style. Format is:
+# postgis://USER:PASSWORD@HOST:PORT/DBNAME
+#DATABASE_URL=postgis://parking_permits_user:parking_permits_password@db:5432/parking_permits_db
+
+# Jwt token authentication, not yet in use. This settings Specifies
+# the value that must be present in the "aud"-key of the token presented
+# by a client when making an authenticated request. Parking Permits uses this
+# key for verifying that the token was meant for accessing this particular
+# instance (the tokens are signed, see below).
+#TOKEN_AUTH_ACCEPTED_AUDIENCE=string-identifying-this-tvp-instance
+
+# This key will be used to verify the JWT token is from trusted
+# Identity Provider. The provider must have signed
+# the JWT TOKEN using this shared secret
+# Note: Wre are not yet using token authentication
+# Does not correspond to standard Django setting
+#TOKEN_AUTH_SHARED_SECRET=
+
+# Secret used for various functions within Django.
+# Django setting: SECRET_KEY https://docs.djangoproject.com/en/3.0/ref/settings/#secret-key
+#SECRET_KEY=
+
+# List of Host-values, that Parking Permits will accept in requests.
+# https://docs.djangoproject.com/en/3.0/topics/security/#host-headers-virtual-hosting
+# Specified as a comma separated list of allowed values. Note that this does
+# NOT matter if you are running with DEBUG
+# Django setting: ALLOWED_HOSTS https://docs.djangoproject.com/en/3.0/ref/settings/#allowed-hosts
+#ALLOWED_HOSTS=example.address.com,another.address.com
+
+# List of tuples (or just e-mail addresses) specifying Administrators of this
+# Parking Permits instance. Django uses this only when logging is configured to
+# send exceptions to admins. Parking Permits does not do this. Still you may want
+# to set this for documentation
+# Django setting: ADMINS https://docs.djangoproject.com/en/3.0/ref/settings/#admins
+# ADMINS=admin@this-tvp.instance,another-admin@this-tvp.instance
+
+# Cookie prefix is added to the every cookie set by Parking Permits. These are
+# mostly used when accessing the internal Django admin site. This applies
+# to django session cookie and csrf cookie
+# Django setting: prepended to CSRF_COOKIE_NAME and SESSION_COOKIE_NAME
+COOKIE_PREFIX=parking-permits
+
+# Django INTERNAL_IPS setting allows some debugging aids for the addresses
+# specified here
+# DJango setting: INTERNAL_IPS https://docs.djangoproject.com/en/3.0/ref/settings/#internal-ips
+INTERNAL_IPS=127.0.0.1
+
+# Specifies a header that is trusted to indicate that the request was using
+# https while traversing over the Internet at large. This is used when
+# a proxy terminates the TLS connection and forwards the request over
+# a secure network. Specified using a tuple.
+# Django setting: SECURE_PROXY_SSL_HEADER https://docs.djangoproject.com/en/3.0/ref/settings/#secure-proxy-ssl-header
+#SECURE_PROXY_SSL_HEADER=('HTTP_X_FORWARDED_PROTO', 'https')
+
+# Specifies that Django is to use `X-Forwarded-Host` as it would normally
+# use the `Host`-header. This is necessary when `Host`-header is used for
+# routing the requests in a network of reverse proxies. `X-Forwarded-Host`
+# is then used to carry the Host-header value supplied by the origin client.
+# This affects how ALLOWED_HOSTS behaves, as well.
+# Django setting: https://docs.djangoproject.com/en/3.0/ref/settings/#use-x-forwarded-host
+# TRUST_X_FORWARDED_HOST=False
+
+# The default value for Resource.timezone field
+#RESOURCE_DEFAULT_TIMEZONE=Europe/Helsinki
+
+# A list of origins that are authorized to make cross-site HTTP requests. Defaults to [].
+# An Origin is defined by the CORS RFC Section 3.2 as a URI scheme + hostname + port,
+# or one of the special values 'null' or 'file://'.
+# Default ports (HTTPS = 443, HTTP = 80) are optional here.
+#CORS_ALLOWED_ORIGINS=
+
+# Boolean. Set true to enable audit logging.
+# Logs are saved to database configured to be used by django.
+#AUDIT_LOGGING_ENABLED=
+
+# Used in development environments to control registering to redhat developer account.
+# Set to local to indicate the docker isn't run in openshift/kubernetes environment.
+# Do not set in production or openshift environments.
+#BUILD_MODE=local
+
+# Account name used in development environments to login to redhat developer subscription
+# to gain access to some build tools needed to install lib gdal.
+# Register at https://developers.redhat.com/register and confirm your email address to
+# enable the account.
+# BUILD_MODE needs to be set to local for this to have effect.
+# Do not set in production or openshift/kubernetes environments.
+#REDHAT_USERNAME=
+
+# Password used in development environments to login to redhat developer subscription
+# to gain access to some build tools needed to install lib gdal.
+# BUILD_MODE needs to be set to local for this to have effect.
+# Do not set in production or openshift/kubernetes environments.
+#REDHAT_PASSWORD=
+
+APPLY_MIGRATIONS=True
+CREATE_SUPERUSER=True
+DEV_SERVER=True
+DJANGO_SECRET_KEY=NotImportantHere
+DJANGO_SUPERUSER_EMAIL=admin@kool-kids.com
+DJANGO_SUPERUSER_PASSWORD=coconut
+DJANGO_SUPERUSER_USERNAME=admin
+INSTALL_PRECOMMIT=True
+WAIT_FOR_IT_ADDRESS=db:5432

--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-# .env
+.env
 .env/
 .venv/
 env/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,81 @@
-ARG BASE_IMAGE=python
-ARG PYTHON_VERSION=3.9.4
-ARG IMAGE_VARIANT=slim
+# Dockerfile for Parking Permits backend
 
 # ==============================
-FROM ${BASE_IMAGE}:${PYTHON_VERSION}-${IMAGE_VARIANT} AS base_stage
+FROM registry.access.redhat.com/ubi8/python-39 as appbase
 # ==============================
 
-RUN groupadd --system --gid 2000 appgroup && \
-    useradd  --system --gid      appgroup --create-home --uid 3000 appuser
+USER root
+
+RUN rm /etc/rhsm-host
+
+ARG LOCAL_REDHAT_USERNAME
+ARG LOCAL_REDHAT_PASSWORD
+ARG BUILD_MODE
+
+RUN if [ "x$BUILD_MODE" = "xlocal" ] ;\
+    then \
+        subscription-manager register --username $LOCAL_REDHAT_USERNAME --password $LOCAL_REDHAT_PASSWORD --auto-attach; \
+    else \
+        subscription-manager register --username ${REDHAT_USERNAME} --password ${REDHAT_PASSWORD} --auto-attach; \
+    fi
+
+RUN subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+RUN yum -y update
+
+RUN rpm -Uvh https://download.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+RUN yum install -y gdal
+
+RUN useradd -ms /bin/bash -d /app parking_permits
+
+RUN chown parking_permits /opt/app-root/lib/python3.9/site-packages
+RUN chown parking_permits /opt/app-root/lib/python3.9/site-packages/*
 
 WORKDIR /app
 
-EXPOSE 8000
+RUN subscription-manager remove --all
 
 # Add tini init system https://github.com/krallin/tini
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-ENV PYTHONDONTWRITEBYTECODE true
-ENV PYTHONUNBUFFERED true
+ENV PYTHONDONTWRITEBYTECODE True
+ENV PYTHONUNBUFFERED True
+
+# Copy and install requirements files to image
+COPY requirements.txt /app/
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY docker-entrypoint.sh /app/
 ENTRYPOINT ["/tini", "--", "/app/docker-entrypoint.sh"]
 
-COPY requirements.txt /app/
-RUN pip install --no-cache-dir -r /app/requirements.txt
+EXPOSE 8000
 
 # ==============================
-FROM base_stage AS development_stage
+FROM appbase as development_stage
 # ==============================
 
 # git is needed for 'pre-commit install' to work
-RUN apt-get update && apt-get install --yes --no-install-recommends git
+RUN yum install git
 
+# Copy and install development requirements files to image
 COPY requirements-dev.txt /app/
 RUN pip install --no-cache-dir -r /app/requirements-dev.txt
 
 COPY . /app/
 
-USER appuser:appgroup
+RUN chgrp -R 0 /app
+RUN chmod g=u -R /app
 
 # ==============================
-FROM base_stage AS production_stage
+FROM appbase as production_stage
 # ==============================
 
 COPY . /app/
 
+RUN chgrp -R 0 /app
+RUN chmod g=u -R /app
+
 RUN DJANGO_SECRET_KEY="only-used-for-collectstatic" DATABASE_URL="sqlite:///" \
     python /app/manage.py collectstatic --noinput
-
-USER appuser:appgroup

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
-### Parking Permits API
+# Parking Permits API
 
 Backend repository for parking permits service developed by City of Helsinki.
 
 Instructions in this README.md are written with an experienced Python developer in mind. For example, "docker-compose up" means you already know what docker and docker-compose are and you already have both installed locally. This helps to keep the README.md concise.
 
-### Setting up local development environment with Docker
+## Setting up local development environment with Docker
 
-- Clone the repository
+In order to create placeholder for your own environment variables file, copy and rename `.env.example` to `.env`.
 
-- Start the application
+You'll need a redhat developer account to gain access to RedHat subscriptions
+needed to run the docker image.
+
+Register at https://developers.redhat.com/register and confirm your email address. 
+
+Set following environment variables in .env file:
+- BUILD_MODE=local
+- REDHAT_USERNAME=your redhat account username 
+- REDHAT_PASSWORD=your redhat account password
+
+Then you can run docker image with:
 
   ```bash
   docker-compose up
@@ -20,7 +30,7 @@ Instructions in this README.md are written with an experienced Python developer 
 
 - Done!
 
-### Setting up local development environment with PyEnv and VirtualEnvWrapper
+## Setting up local development environment with PyEnv and VirtualEnvWrapper
 
 ```
 pyenv install -v 3.9.0
@@ -39,7 +49,7 @@ pip-sync requirements.txt requirements-dev.txt
 ```
 
 
-### Managing project packages
+## Managing project packages
 
 - We use `pip-tools` to manage python packages we need
 - After adding a new package to requirements(-dev).in file, compile it and re-build the Docker image so that the container would have access to the new package
@@ -48,7 +58,7 @@ pip-sync requirements.txt requirements-dev.txt
   docker-compose up --build
   ```
 
-### Running tests
+## Running tests
 
 - You can run all the tests with:
   ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,33 @@
 version: "3.9"
 
 services:
-  database:
-    # https://registry.hub.docker.com/r/postgis/postgis
+  parking-permits-database:
     image: postgis/postgis:13-3.1
     volumes:
       - database-volume:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: my_postgres_db
-      POSTGRES_USER: my_postgres_user
-      POSTGRES_PASSWORD: my_postgres_password
+      POSTGRES_DB: parking_permits_db
+      POSTGRES_USER: parking_permits_user
+      POSTGRES_PASSWORD: parking_permits_password
     ports:
       - "127.0.0.1:5555:5432"
 
   graphql-api:
+    image: parking_permits_api
     build:
-      context: .
+      context: ./
+      dockerfile: ./Dockerfile
       target: development_stage
+      args:
+        BUILD_MODE: ${BUILD_MODE}
+        LOCAL_REDHAT_USERNAME: ${REDHAT_USERNAME}
+        LOCAL_REDHAT_PASSWORD: ${REDHAT_PASSWORD}
+    env_file:
+      - .env
     volumes:
       - .:/app:cached
     ports:
       - "127.0.0.1:8000:8000"
-    environment:
-      - APPLY_MIGRATIONS=true
-      - CREATE_SUPERUSER=true
-      - DATABASE_URL=postgres://my_postgres_user:my_postgres_password@database:5432/my_postgres_db
-      - DEBUG=true
-      - DEV_SERVER=true
-      - DJANGO_SECRET_KEY=NotImportantHere
-      - DJANGO_SUPERUSER_EMAIL=admin@kool-kids.com
-      - DJANGO_SUPERUSER_PASSWORD=coconut
-      - DJANGO_SUPERUSER_USERNAME=admin
-      - INSTALL_PRECOMMIT=true
-      - WAIT_FOR_IT_ADDRESS=database:5432
 
 volumes:
   database-volume: {}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,19 +6,19 @@ if [[ "$WAIT_FOR_IT_ADDRESS" ]]; then
     ./wait-for-it.sh $WAIT_FOR_IT_ADDRESS --timeout=30
 fi
 
-if [[ "$APPLY_MIGRATIONS" = "true" ]]; then
+if [[ "$APPLY_MIGRATIONS" = "True" ]]; then
     python /app/manage.py migrate --noinput
 fi
 
-if [[ "$INSTALL_PRECOMMIT" = "true" ]]; then
+if [[ "$INSTALL_PRECOMMIT" = "True" ]]; then
     pre-commit install --overwrite
 fi
 
-if [[ "$CREATE_SUPERUSER" = "true" ]]; then
+if [[ "$CREATE_SUPERUSER" = "True" ]]; then
     python /app/manage.py createsuperuser --noinput || true
 fi
 
-if [[ "$DEV_SERVER" = "true" ]]; then
+if [[ "$DEV_SERVER" = "True" ]]; then
     python /app/manage.py runserver 0.0.0.0:8000
 else
     gunicorn


### PR DESCRIPTION
The PR contains the following enhancements:

- Use RedHat base image with GDAL 3 support
- Allow `.env` -file usage
- Add `.env.example` template for environment variables
- Ignore `.env`-file by default
- Update default naming to use `parking_permits`