### PR TITLE
Read .env file content to settings on local development

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -1,14 +1,23 @@
-from os import getenv
+from os import getenv, path
 from pathlib import Path
 
 import dj_database_url
+import environ
+
+env = environ.Env(
+    DEBUG=(bool, False),
+    DJANGO_SECRET_KEY=(str, ""),
+    ALLOWED_HOSTS=(list, ["*"]),
+    DATABASE_URL=(str, "sqlite:////tmp/my-tmp-sqlite.db"),
+)
+
+if path.exists(".env"):
+    environ.Env().read_env(".env")
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-
-SECRET_KEY = getenv("DJANGO_SECRET_KEY")
-DEBUG = getenv("DEBUG") == "True"
-
-ALLOWED_HOSTS = ["*"]
+DEBUG = env("DEBUG")
+SECRET_KEY = env("DJANGO_SECRET_KEY")
+ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 
 AUTH_USER_MODEL = "users_app.CustomUser"
 
@@ -61,9 +70,7 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "project.wsgi.application"
 
-DATABASE_URL = getenv("DATABASE_URL")
-
-DATABASES = {"default": dj_database_url.parse(DATABASE_URL)}
+DATABASES = {"default": dj_database_url.parse(env("DATABASE_URL"))}
 
 
 AUTH_PASSWORD_VALIDATORS = [

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 ariadne==0.13.0                               # schema-first graphql server implementation
 dj-database-url==0.5.0                        # to be able to parse DATABASE_URL
+django-environ==0.4.5                         # Read .env file
 django==3.2                                   # web framework itself
 djangorestframework==3.12.4                   # creating rest APIs
 gunicorn==20.1.0                              # application server

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ asgiref==3.3.4
     # via django
 dj-database-url==0.5.0
     # via -r requirements.in
+django-environ==0.4.5
+    # via -r requirements.in
 django==3.2
     # via
     #   -r requirements.in


### PR DESCRIPTION
Currently .env files are not loaded while developing locally without docker.
This PR will work for both the case developer developing with docker or without docker.