### PR TITLE
Update end time calculation

### DIFF
--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -3,6 +3,7 @@ from functools import reduce
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
+from django.utils import timezone
 
 
 def apply_ordering(queryset, order_by):
@@ -44,5 +45,7 @@ def diff_months_ceil(start_date, end_date):
 
 
 def get_end_time(start_time, diff_months):
-    end_time = start_time + relativedelta(months=diff_months)
-    return end_time.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_time = start_time + relativedelta(months=diff_months, days=-1)
+    return timezone.make_aware(
+        end_time.replace(hour=23, minute=59, second=0, microsecond=0, tzinfo=None)
+    )

--- a/project/settings.py
+++ b/project/settings.py
@@ -111,7 +111,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "fi"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "Europe/Helsinki"
 
 USE_I18N = True
 


### PR DESCRIPTION
Previously the end time is set to the 0:00 on the same date
as start time of the ending monthly. Now changed to use the
23:59 on the previous date of the ending month

Refs: PV-294