### PR TITLE
Subscription id can be null

### DIFF
--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -89,7 +89,7 @@ class OrderView(APIView):
                     permit.status = ParkingPermitStatus.VALID
                 else:
                     permit.status = ParkingPermitStatus.PAYMENT_IN_PROGRESS
-                permit.subscription_id = item.get("subscriptionId")
+                permit.subscription_id = item.get("subscriptionId", "")
                 permit.order_id = item.get("orderId")
                 permit.save()
 


### PR DESCRIPTION
Subcription id exist only if the order is open
ended. For fixed term there is no subscription
therefore the field can be nullable.

Refs None