### PR TITLE
Ending of valid permit should delete all draft permit

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -199,6 +199,8 @@ class CustomerPermit:
                 reversion.set_user(self.customer.user)
                 comment = get_reversion_comment(EventType.CHANGED, permit)
                 reversion.set_comment(comment)
+        # Delete all the draft permit while ending the customer valid permits
+        self.customer_permit_query.filter(status=DRAFT).delete()
         return True
 
     def _update_fields_to_all_draft(self, data):


### PR DESCRIPTION
In order to prevent the user having secondary permit
without primary, system should delete all the draft
permits of user if he/she delete the valid permits.

Refs PV-301