### PR TITLE
Add backend resolvers for update (edit) resident permit

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -104,7 +104,7 @@ def resolve_vehicle(obj, info, reg_number, national_id_number):
     return vehicle
 
 
-def create_customer(customer_info):
+def update_or_create_customer(customer_info):
     if customer_info["address_security_ban"]:
         customer_info.pop("first_name", None)
         customer_info.pop("last_name", None)
@@ -137,19 +137,26 @@ def create_customer(customer_info):
             primary=True,
         )
         customer_data["primary_address"] = address
-    return Customer.objects.create(**customer_data)
+    else:
+        customer_data["primary_address"] = None
+    return Customer.objects.update_or_create(
+        national_id_number=customer_info["national_id_number"], defaults=customer_data
+    )[0]
 
 
-def create_vehicle(vehicle_info):
-    return Vehicle.objects.create(
-        registration_number=vehicle_info["registration_number"],
-        manufacturer=vehicle_info["manufacturer"],
-        model=vehicle_info["model"],
-        low_emission_vehicle=vehicle_info["is_low_emission"],
-        consent_low_emission_accepted=vehicle_info["consent_low_emission_accepted"],
-        serial_number=vehicle_info["serial_number"],
-        category=vehicle_info["category"],
-    )
+def update_or_create_vehicle(vehicle_info):
+    vehicle_data = {
+        "registration_number": vehicle_info["registration_number"],
+        "manufacturer": vehicle_info["manufacturer"],
+        "model": vehicle_info["model"],
+        "low_emission_vehicle": vehicle_info["is_low_emission"],
+        "consent_low_emission_accepted": vehicle_info["consent_low_emission_accepted"],
+        "serial_number": vehicle_info["serial_number"],
+        "category": vehicle_info["category"],
+    }
+    return Vehicle.objects.update_or_create(
+        registration_number=vehicle_info["registration_number"], defaults=vehicle_data
+    )[0]
 
 
 @mutation.field("createResidentPermit")
@@ -158,18 +165,10 @@ def create_vehicle(vehicle_info):
 @transaction.atomic
 def resolve_create_resident_permit(obj, info, permit):
     customer_info = permit["customer"]
-    customer = Customer.objects.filter(
-        national_id_number=customer_info["national_id_number"]
-    ).first()
-    if not customer:
-        customer = create_customer(customer_info)
+    customer = update_or_create_customer(customer_info)
 
     vehicle_info = permit["vehicle"]
-    vehicle = Vehicle.objects.filter(
-        registration_number=vehicle_info["registration_number"]
-    ).first()
-    if not vehicle:
-        vehicle = create_vehicle(vehicle_info)
+    vehicle = update_or_create_vehicle(vehicle_info)
 
     parking_zone = ParkingZone.objects.get(name=customer_info["zone"])
     with reversion.create_revision():

--- a/parking_permits/exceptions.py
+++ b/parking_permits/exceptions.py
@@ -44,3 +44,7 @@ class CreateTalpaProductError(ParkingPermitBaseException):
 
 class OrderCreationFailed(ParkingPermitBaseException):
     pass
+
+
+class UpdatePermitError(ParkingPermitBaseException):
+    pass

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -145,7 +145,6 @@ input AddressInput {
 }
 
 input ZoneInput {
-  id: ID!
   name: String
   description: String
   descriptionSv: String
@@ -157,7 +156,7 @@ input CustomerInput {
   lastName: String
   nationalIdNumber: String
   primaryAddress: AddressInput
-  zone: String
+  zone: ZoneInput!
   email: String
   phoneNumber: String
   addressSecurityBan: Boolean
@@ -180,6 +179,7 @@ input ResidentPermitInput {
   vehicle: VehicleInput
   status: ParkingPermitStatus!
   startTime: String
+  endTime: String
   monthCount: Int
 }
 
@@ -195,4 +195,5 @@ enum PermitEndType {
 type Mutation {
   createResidentPermit(permit: ResidentPermitInput!): MutationResponse
   endPermit(permitId: Int!, endType: PermitEndType!, iban: String): MutationResponse
+  updateResidentPermit(permitId: ID!, permitInfo: ResidentPermitInput!): MutationResponse
 }


### PR DESCRIPTION
Add Admin UI graphql resolver for updating resident permit

- Admin can update customer information of the permit, but cannot change the customer of the permit
- Admin can update vehicle information as well as change the vehicle of the permit
- Apart from the things mentioned above, admins are only allowed to change the status and the parking zone of the permit

This PR does not implement refund handling when, for example, changing address or vehicle

Refs: PV-229