### PR TITLE
Fix resident UI end time calculation

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -2,7 +2,6 @@ import decimal
 
 import reversion
 from dateutil.parser import isoparse, parse
-from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone as tz
@@ -24,7 +23,7 @@ from .models.parking_permit import (
     ParkingPermitStatus,
 )
 from .reversion import EventType, get_reversion_comment
-from .utils import diff_months_floor
+from .utils import diff_months_floor, get_end_time
 
 IMMEDIATELY = ParkingPermitStartType.IMMEDIATELY
 OPEN_ENDED = ContractType.OPEN_ENDED
@@ -41,10 +40,6 @@ def next_day():
 
 def two_week_from_now():
     return tz.localtime(tz.now() + tz.timedelta(weeks=2))
-
-
-def get_end_time(start, month=0):
-    return tz.localtime(start + relativedelta(months=month))
 
 
 class CustomerPermit:

--- a/parking_permits/talpa/order.py
+++ b/parking_permits/talpa/order.py
@@ -35,7 +35,7 @@ class TalpaOrderManager:
     @classmethod
     def _get_product_description(cls, product):
         start_time = product.start_date.strftime(DATE_FORMAT)
-        end_time = product.start_date.strftime(DATE_FORMAT)
+        end_time = product.end_date.strftime(DATE_FORMAT)
         return f"{start_time} - {end_time}"
 
     @classmethod

--- a/parking_permits/talpa/order.py
+++ b/parking_permits/talpa/order.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import requests
 from django.conf import settings
 from django.db import transaction
+from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from parking_permits.exceptions import OrderCreationFailed
@@ -73,6 +74,7 @@ class TalpaOrderManager:
 
     @classmethod
     def _append_detail_meta(cls, item, permit):
+        start_time = timezone.localtime(permit.start_time).strftime(DATE_FORMAT)
         item["meta"] += [
             {
                 "key": "permitDuration",
@@ -84,7 +86,7 @@ class TalpaOrderManager:
             {
                 "key": "startDate",
                 "label": _("Parking permit start date*"),
-                "value": f"{permit.start_time.strftime(DATE_FORMAT)}",
+                "value": start_time,
                 "visibleInCheckout": True,
                 "ordinal": 2,
             },
@@ -99,11 +101,12 @@ class TalpaOrderManager:
             },
         ]
         if permit.end_time:
+            end_time = timezone.localtime(permit.end_time).strftime(TIME_FORMAT)
             item["meta"].append(
                 {
                     "key": "endDate",
                     "label": _("Parking permit expiration date"),
-                    "value": f"{permit.end_time.strftime(TIME_FORMAT)}",
+                    "value": end_time,
                     "visibleInCheckout": True,
                     "ordinal": 3,
                 }


### PR DESCRIPTION
Fixed some issues regarding the end time calculation for customer permits. 

- Use the the `get_end_time` method from utils module
- Converted times to local time (when fetched from db it's in UTC time) before formatting to a string. 

![image](https://user-images.githubusercontent.com/1997039/154309711-6b93b132-55c7-477e-951f-2f34852d94d9.png)

Refs: PV-343