### PR TITLE
Add resolvers for changing address and related price changes 

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -257,14 +257,11 @@ def resolve_update_resident_permit(obj, info, permit_id, permit_info, iban=None)
         parking_zone, vehicle_info["is_low_emission"]
     )
     total_price_change = sum([item["price_change"] for item in price_change_list])
+
+    # only create new order when emission status or parking zone changed
     should_create_new_order = (
-        # only create new order when emission status or parking zone changed
-        (
-            permit.vehicle.is_low_emission != vehicle_info["is_low_emission"]
-            or permit.parking_zone_id != parking_zone.id
-        )
-        and original_order
-        and original_order.is_confirmed
+        permit.vehicle.is_low_emission != vehicle_info["is_low_emission"]
+        or permit.parking_zone_id != parking_zone.id
     )
 
     customer = update_or_create_customer(customer_info)
@@ -283,7 +280,7 @@ def resolve_update_resident_permit(obj, info, permit_id, permit_info, iban=None)
     if should_create_new_order:
         logger.info(f"Creating renewal order for permit: {permit.identifier}")
         new_order = Order.objects.create_renewal_order(
-            original_order, status=OrderStatus.CONFIRMED
+            customer, status=OrderStatus.CONFIRMED
         )
         logger.info(f"Creating renewal order completed: {new_order.id}")
         if total_price_change < 0:

--- a/parking_permits/exceptions.py
+++ b/parking_permits/exceptions.py
@@ -60,3 +60,7 @@ class ParkingZoneError(ParkingPermitBaseException):
 
 class ParkkihubiPermitError(ParkingPermitBaseException):
     pass
+
+
+class AddressError(ParkingPermitBaseException):
+    pass

--- a/parking_permits/models/address.py
+++ b/parking_permits/models/address.py
@@ -50,3 +50,9 @@ class Address(SerializableMixin, TimestampedModelMixin, UUIDPrimaryKeyMixin):
             self.street_number,
             self.city,
         )
+
+    def get_zone(self):
+        if not self.zone:
+            self.zone = ParkingZone.objects.get_for_location(self.location)
+            self.save()
+        return self.zone

--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -1,3 +1,6 @@
+import logging
+from collections import Counter
+
 from ariadne import (
     MutationType,
     QueryType,
@@ -6,18 +9,23 @@ from ariadne import (
     snake_case_fallback_resolvers,
 )
 from ariadne.contrib.federation import FederatedObjectType
+from django.db import transaction
 from django.db.utils import IntegrityError
+from django.utils.translation import ugettext
 
 from project.settings import BASE_DIR
 
 from .customer_permit import CustomerPermit
 from .decorators import is_authenticated
-from .models import Address, Customer, ParkingZone, Vehicle
-from .models.order import Order
+from .exceptions import AddressError, ObjectNotFound, ParkingZoneError
+from .models import Address, Customer, ParkingZone, Refund, Vehicle
+from .models.order import Order, OrderStatus
 from .models.parking_permit import ParkingPermit, ParkingPermitStatus
 from .services.hel_profile import HelsinkiProfile
 from .services.kmo import get_address_detail_from_kmo
 from .talpa.order import TalpaOrderManager
+
+logger = logging.getLogger("db")
 
 helsinki_profile_query = load_schema_from_path(
     BASE_DIR / "parking_permits" / "schema" / "helsinki_profile.graphql"
@@ -81,6 +89,51 @@ def resolve_user_profile(_, info, *args):
     )
 
     return customer_obj
+
+
+def validate_customer_address(customer, address_id):
+    """Check if the given address a valid customer address
+
+    Customers can only update the permits to their only addresses,
+    i.e. either the primary address or the other address
+    """
+    addr_ids = [customer.primary_address_id, customer.other_address_id]
+    allowed_addr_ids = [str(addr_id) for addr_id in addr_ids if addr_id is not None]
+    if address_id not in allowed_addr_ids:
+        logger.error("Not a valid customer address")
+        raise AddressError(ugettext("Not a valid customer address"))
+
+    try:
+        return Address.objects.get(id=address_id)
+    except Address.DoesNotExist:
+        logger.error(f"updatePermitsAddress: address with id {address_id} not found")
+        raise ObjectNotFound(ugettext("Address not found"))
+
+
+@query.field("getUpdateAddressPriceChanges")
+@is_authenticated
+@convert_kwargs_to_snake_case
+def resolve_get_update_address_price_changes(_, info, address_id):
+    customer = info.context["request"].user.customer
+    address = validate_customer_address(customer, address_id)
+    new_zone = address.get_zone()
+
+    permits = ParkingPermit.objects.active().filter(customer=customer)
+    if len(permits) == 0:
+        logger.error(f"No active permits for the customer: {customer}")
+        raise ObjectNotFound(ugettext("No active permits for the customer"))
+
+    permit_price_changes = []
+    for permit in permits:
+        permit_price_changes.append(
+            {
+                "permit": permit,
+                "price_changes": permit.get_price_change_list(
+                    new_zone, permit.vehicle.is_low_emission
+                ),
+            }
+        )
+    return permit_price_changes
 
 
 @mutation.field("deleteParkingPermit")
@@ -156,3 +209,94 @@ def resolve_create_order(_, info):
     order = Order.objects.create_for_permits(permits)
     checkout_url = TalpaOrderManager.send_to_talpa(order)
     return {"success": True, "order": {"checkout_url": checkout_url}}
+
+
+@mutation.field("changeAddress")
+@is_authenticated
+@convert_kwargs_to_snake_case
+@transaction.atomic
+def resolve_change_address(_, info, address_id, iban=None):
+    customer = info.context["request"].user.customer
+    address = validate_customer_address(customer, address_id)
+    new_zone = address.get_zone()
+
+    permits = ParkingPermit.objects.active().filter(customer=customer)
+    if len(permits) == 0:
+        logger.error(f"No active permits for the customer: {customer}")
+        raise ObjectNotFound(ugettext("No active permits for the customer"))
+
+    # check that active permits are all in the same zone
+    permit_zone_ids = [permit.parking_zone_id for permit in permits]
+    if len(set(permit_zone_ids)) > 1:
+        logger.error(
+            f"updatePermitsAddress: active permits have conflict parking zones. Customer: {customer}"
+        )
+        raise ParkingZoneError(ugettext("Conflict parking zones for active permits"))
+
+    if permit_zone_ids[0] == new_zone.id:
+        logger.info("No changes to the parking zone")
+        return {"success": True}
+
+    fixed_period_permits = [permit for permit in permits if permit.is_fixed_period]
+    if len(fixed_period_permits) > 0:
+        # There can be two cases regarding customer's active permits:
+        #
+        # 1. A single permit or two permits are created at the same time.
+        # In this case, there will be a single order for the permit[s],
+        # and the total price changes for multiple permits are combined.
+        # Only a single refund will be created if the price of the permits
+        # goes down.
+        #
+        # 2. Two permits are created at different times.
+        # In this case, permits will have different orders, and the total
+        # price change need to be stored separately. We need to create
+        # separate refunds also if the price of the permits goes down.
+        #
+        # The total_price_change_by_order Counter (with permit order as the key)
+        # serves the purpose to combine the price change for multiple permits
+        # if they belong to the same order and create separate entries otherwise.
+        total_price_change_by_order = Counter()
+        for permit in fixed_period_permits:
+            price_change_list = permit.get_price_change_list(
+                new_zone, permit.vehicle.is_low_emission
+            )
+            permit_total_price_change = sum(
+                [item["price_change"] for item in price_change_list]
+            )
+            total_price_change_by_order.update(
+                {permit.order: permit_total_price_change}
+            )
+
+        # total price changes for customer's all valid permits
+        customer_total_price_change = sum(total_price_change_by_order.values())
+        if customer_total_price_change > 0:
+            # if price of the permits goes higher, the customer needs to make
+            # extra payments through Talpa before the orders can be set to confirmed
+            new_order_status = OrderStatus.DRAFT
+        else:
+            new_order_status = OrderStatus.CONFIRMED
+
+        for order, order_total_price_change in total_price_change_by_order.items():
+            Order.objects.create_renewal_order(customer, status=new_order_status)
+            if order_total_price_change < 0:
+                refund = Refund.objects.create(
+                    name=str(customer),
+                    order=order,
+                    amount=-order_total_price_change,
+                    iban=iban if iban else "",
+                    description=f"Refund for updating permits zone (customer switch address to: {address})",
+                )
+                logger.info(f"Refund for updating permits zone created: {refund}")
+
+        if customer_total_price_change > 0:
+            for permit in fixed_period_permits:
+                permit.status = ParkingPermitStatus.PAYMENT_IN_PROGRESS
+                permit.save()
+
+    open_ended_permits = [permit for permit in permits if permit.is_open_ended]
+    if len(open_ended_permits) > 0:
+        # TODO: handling open ended permits is not specified
+        pass
+
+    permits.update(parking_zone=new_zone)
+    return {"success": True}

--- a/parking_permits/schema/parking_permit.graphql
+++ b/parking_permits/schema/parking_permit.graphql
@@ -88,9 +88,26 @@ type PermitResult {
   permits: [PermitNode]
 }
 
+type PermitPriceChangeItem {
+  product: String!
+  previousPrice: Float!
+  newPrice: Float!
+  priceChange: Float!
+  priceChangeVat: Float!
+  startDate: String!
+  endDate: String!
+  monthCount: Int!
+}
+
+type PermitPriceChangeResult {
+  permit: PermitNode!
+  priceChanges: [PermitPriceChangeItem]!
+}
+
 type Query {
   profile: CustomerNode!
   getPermits: PermitResult
+  getUpdateAddressPriceChanges(addressId: ID!): [PermitPriceChangeResult]
 }
 
 type updateVehicleResult {
@@ -119,6 +136,10 @@ type TalpaOrderResult {
   order: TalpaOrderNode
 }
 
+type ChangeAddressResult {
+  success: Boolean!
+}
+
 type Mutation {
   createParkingPermit(zoneId: ID!): PermitResult!
   createOrder: TalpaOrderResult!
@@ -132,6 +153,7 @@ type Mutation {
     vehicleId: ID!
     registration: String!
   ): updateVehicleResult!
+  changeAddress(addressId: ID!, iban: String): ChangeAddressResult!
 }
 
 input ParkingPermitInput {

--- a/parking_permits/tests/models/test_order.py
+++ b/parking_permits/tests/models/test_order.py
@@ -82,7 +82,7 @@ class TestOrderManager(TestCase):
         permit.save()
 
         with freeze_time(timezone.make_aware(datetime(2021, 5, 5))):
-            new_order = Order.objects.create_renewal_order(order)
+            new_order = Order.objects.create_renewal_order(self.customer)
             order_items = new_order.order_items.all().order_by("start_date")
             self.assertEqual(order_items.count(), 2)
             self.assertEqual(order_items[0].unit_price, Decimal(15))
@@ -104,10 +104,10 @@ class TestOrderManager(TestCase):
             end_time=end_time,
             month_count=6,
         )
-        order = Order.objects.create_for_permits([permit])
+        Order.objects.create_for_permits([permit])
         with freeze_time(timezone.make_aware(datetime(2021, 5, 5))):
             with self.assertRaises(OrderCreationFailed):
-                Order.objects.create_renewal_order(order)
+                Order.objects.create_renewal_order(self.customer)
 
     def test_create_renewable_order_should_raise_error_for_open_ended_permits(self):
         start_time = timezone.make_aware(datetime(2021, 3, 15))
@@ -121,12 +121,12 @@ class TestOrderManager(TestCase):
             end_time=end_time,
             month_count=6,
         )
-        order = Order.objects.create_for_permits([permit])
+        Order.objects.create_for_permits([permit])
         permit.status = ParkingPermitStatus.VALID
         permit.save()
         with freeze_time(timezone.make_aware(datetime(2021, 5, 5))):
             with self.assertRaises(OrderCreationFailed):
-                Order.objects.create_renewal_order(order)
+                Order.objects.create_renewal_order(self.customer)
 
 
 class TestOrder(TestCase):


### PR DESCRIPTION
Two resolvers are added:

- resolve_get_update_address_price_changes: returns the
price changes on the permit after switch to the new address

- resolve_change_address: update the address of customer's active
permits

Refs: PV-334