### PR TITLE
Change address extra payment case

### DIFF
--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -256,6 +256,18 @@ class Order(SerializableMixin, TimestampedModelMixin, UUIDPrimaryKeyMixin):
     def total_price_vat(self):
         return sum([item.total_price_vat for item in self.order_items.all()])
 
+    @property
+    def total_payment_price(self):
+        return sum([item.total_payment_price for item in self.order_items.all()])
+
+    @property
+    def total_payment_price_net(self):
+        return sum([item.total_payment_price_net for item in self.order_items.all()])
+
+    @property
+    def total_payment_price_vat(self):
+        return sum([item.total_payment_price_vat for item in self.order_items.all()])
+
 
 class OrderItem(SerializableMixin, TimestampedModelMixin, UUIDPrimaryKeyMixin):
     talpa_order_item_id = models.UUIDField(
@@ -324,3 +336,23 @@ class OrderItem(SerializableMixin, TimestampedModelMixin, UUIDPrimaryKeyMixin):
     @property
     def total_price_vat(self):
         return self.total_price * self.vat
+
+    @property
+    def payment_unit_price_net(self):
+        return self.payment_unit_price * (1 - self.vat)
+
+    @property
+    def payment_unit_price_vat(self):
+        return self.payment_unit_price * self.vat
+
+    @property
+    def total_payment_price(self):
+        return self.quantity * self.payment_unit_price
+
+    @property
+    def total_payment_price_net(self):
+        return self.total_payment_price * (1 - self.vat)
+
+    @property
+    def total_payment_price_vat(self):
+        return self.total_payment_price * self.vat

--- a/parking_permits/schema/parking_permit.graphql
+++ b/parking_permits/schema/parking_permit.graphql
@@ -138,6 +138,7 @@ type TalpaOrderResult {
 
 type ChangeAddressResult {
   success: Boolean!
+  checkoutUrl: String
 }
 
 type Mutation {

--- a/parking_permits/talpa/order.py
+++ b/parking_permits/talpa/order.py
@@ -49,13 +49,13 @@ class TalpaOrderManager:
             "unit": "kk",
             "startDate": date_time_to_utc(order_item.permit.start_time),
             "quantity": order_item.quantity,
-            "priceNet": float(order_item.unit_price_net),
-            "priceVat": float(order_item.unit_price_vat),
-            "priceGross": float(order_item.unit_price),
+            "priceNet": float(order_item.payment_unit_price_net),
+            "priceVat": float(order_item.payment_unit_price_vat),
+            "priceGross": float(order_item.payment_unit_price),
             "vatPercentage": float(order_item.vat_percentage),
-            "rowPriceNet": float(order_item.total_price_net),
-            "rowPriceVat": float(order_item.total_price_vat),
-            "rowPriceTotal": float(order_item.total_price),
+            "rowPriceNet": float(order_item.total_payment_price_net),
+            "rowPriceVat": float(order_item.total_payment_price_vat),
+            "rowPriceTotal": float(order_item.total_payment_price),
             "meta": [
                 {
                     "key": "sourceOrderItemId",
@@ -156,9 +156,9 @@ class TalpaOrderManager:
         return {
             "namespace": settings.NAMESPACE,
             "user": str(order.customer.id),
-            "priceNet": float(order.total_price_net),
-            "priceVat": float(order.total_price_vat),
-            "priceTotal": float(order.total_price),
+            "priceNet": float(order.total_payment_price_net),
+            "priceVat": float(order.total_payment_price_vat),
+            "priceTotal": float(order.total_payment_price),
             "customer": customer,
             "items": items,
         }
@@ -166,7 +166,7 @@ class TalpaOrderManager:
     @classmethod
     def send_to_talpa(cls, order):
         order_data = cls._create_order_data(order)
-        logger.info(f"Sending order to talpa, order Id: {order.id}")
+        logger.info(f"Sending order to talpa, order id: {order.id}")
         response = requests.post(
             cls.url, data=json.dumps(order_data), headers=cls.headers
         )

--- a/parking_permits/talpa/order.py
+++ b/parking_permits/talpa/order.py
@@ -166,6 +166,7 @@ class TalpaOrderManager:
     @classmethod
     def send_to_talpa(cls, order):
         order_data = cls._create_order_data(order)
+        logger.info(f"Sending order to talpa, order Id: {order.id}")
         response = requests.post(
             cls.url, data=json.dumps(order_data), headers=cls.headers
         )
@@ -176,6 +177,10 @@ class TalpaOrderManager:
             raise OrderCreationFailed(_("Failed to create the order"))
 
         response_data = response.json()
+        logger.info(
+            f"Sending order to talpa completed. Talpa order id: {response_data.get('orderId')}"
+        )
+
         with transaction.atomic():
             order.talpa_order_id = response_data.get("orderId")
             order.talpa_subscription_id = response_data.get("subscriptionId")


### PR DESCRIPTION
This PR update the changeAddress resolver for webshop UI to handle the extra payment case, i.e. when the customer change the address from a cheaper parking zone to a more expensive zone. Instead of the unit price, we need to send the payment price, which is the current unit price substracting the unit price for previous zone, to Talpa.

Refs: PV-339