### PR TITLE
Remove non-exist fields when saving vehicles

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -164,10 +164,8 @@ def update_or_create_vehicle(vehicle_info):
         "registration_number": vehicle_info["registration_number"],
         "manufacturer": vehicle_info["manufacturer"],
         "model": vehicle_info["model"],
-        "low_emission_vehicle": vehicle_info["is_low_emission"],
         "consent_low_emission_accepted": vehicle_info["consent_low_emission_accepted"],
         "serial_number": vehicle_info["serial_number"],
-        "category": vehicle_info["category"],
     }
     return Vehicle.objects.update_or_create(
         registration_number=vehicle_info["registration_number"], defaults=vehicle_data


### PR DESCRIPTION
The Vehicle model is refactored for Traifcom integration. This is a
temporary fix so that the graphql API does not crash. Both the UI
components and GraphQL API need to be adjusted to match the new Vehicle
model

no refs