### PR TITLE
Minor refactoring on creating renewal order

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -277,6 +277,9 @@ def resolve_update_resident_permit(obj, info, permit_id, permit_info, iban=None)
             customer, status=OrderStatus.CONFIRMED
         )
         logger.info(f"Creating renewal order completed: {new_order.id}")
+        ParkingPermit.objects.active().fixed_period().filter(customer=customer).update(
+            order=new_order
+        )
         if total_price_change < 0:
             refund = Refund.objects.create(
                 name=str(customer),

--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -191,10 +191,6 @@ class OrderManager(SerializableMixin.SerializableManager):
                     product_detail = next(product_detail_iter, None)
                     order_item_detail = next(order_item_detail_iter, None)
 
-            # change permit active order to the new one
-            permit.order = new_order
-            permit.save()
-
         return new_order
 
 

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -60,6 +60,12 @@ def get_next_identifier():
 
 
 class ParkingPermitManager(SerializableMixin.SerializableManager):
+    def fixed_period(self):
+        return self.filter(contract_type=ContractType.FIXED_PERIOD)
+
+    def open_ended(self):
+        return self.filter(contract_type=ContractType.OPEN_ENDED)
+
     def active(self):
         active_status = [
             ParkingPermitStatus.VALID,

--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -207,7 +207,7 @@ def resolve_change_address(_, info, address_id, iban=None):
         logger.info("No changes to the parking zone")
         return response
 
-    fixed_period_permits = [permit for permit in permits if permit.is_fixed_period]
+    fixed_period_permits = permits.fixed_period()
     if len(fixed_period_permits) > 0:
         # There can be two cases regarding customer's active permits:
         #
@@ -249,13 +249,12 @@ def resolve_change_address(_, info, address_id, iban=None):
         # update permit to the new zone before creating
         # new order as the price is determined by the
         # new zone
-        for permit in fixed_period_permits:
-            permit.parking_zone = new_zone
-            permit.save()
+        fixed_period_permits.update(parking_zone=new_zone)
 
         new_order = Order.objects.create_renewal_order(
             customer, status=new_order_status
         )
+        fixed_period_permits.update(order=new_order)
         for order, order_total_price_change in total_price_change_by_order.items():
             # create refund for each order
             if order_total_price_change < 0:
@@ -272,16 +271,12 @@ def resolve_change_address(_, info, address_id, iban=None):
             # go through talpa checkout process if the price of
             # the permits goes up
             response["checkout_url"] = TalpaOrderManager.send_to_talpa(new_order)
-            for permit in fixed_period_permits:
-                permit.status = ParkingPermitStatus.PAYMENT_IN_PROGRESS
-                permit.save()
+            fixed_period_permits.update(status=ParkingPermitStatus.PAYMENT_IN_PROGRESS)
 
-    open_ended_permits = [permit for permit in permits if permit.is_open_ended]
-    for permit in open_ended_permits:
-        # For open ended permits, it's enough to update the permit zone
-        # as talpa will get the updated price based on new zone when
-        # asking permit price for next month
-        permit.parking_zone = new_zone
-        permit.save()
+    # For open ended permits, it's enough to update the permit zone
+    # as talpa will get the updated price based on new zone when
+    # asking permit price for next month
+    open_ended_permits = permits.open_ended()
+    open_ended_permits.update(parking_zone=new_zone)
 
     return response


### PR DESCRIPTION
Create renwal order should only update the order field
of fixed period permits. The open ended permits are handled
via Talpa hook with auto generated monthly orders

no refs