### PR TITLE
Prevent creating more than 2 permits for the same customer

### DIFF
--- a/parking_permits/models/customer.py
+++ b/parking_permits/models/customer.py
@@ -162,3 +162,7 @@ class Customer(SerializableMixin, TimestampedModelMixin, UUIDPrimaryKeyMixin):
         if self.user:
             self.user.delete()
         self.delete()
+
+    @property
+    def active_permits(self):
+        return self.permits.active()

--- a/parking_permits/models/customer.py
+++ b/parking_permits/models/customer.py
@@ -73,6 +73,13 @@ class Customer(SerializableMixin, TimestampedModelMixin, UUIDPrimaryKeyMixin):
         {"name": "permits"},
     )
 
+    class Meta:
+        verbose_name = _("Customer")
+        verbose_name_plural = _("Customers")
+
+    def __str__(self):
+        return "%s %s" % (self.first_name, self.last_name)
+
     @property
     def age(self):
         ssn = self.national_id_number
@@ -109,13 +116,6 @@ class Customer(SerializableMixin, TimestampedModelMixin, UUIDPrimaryKeyMixin):
             vehicle.vehicle_class in d_class.vehicle_classes
             for d_class in self.driving_licence.driving_classes.all()
         )
-
-    class Meta:
-        verbose_name = _("Customer")
-        verbose_name_plural = _("Customers")
-
-    def __str__(self):
-        return "%s %s" % (self.first_name, self.last_name)
 
     @property
     def can_be_deleted(self):

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -32,6 +32,11 @@ type AddressNode {
   zone: ZoneNode
 }
 
+type CustomerActivePermit {
+  identifier: String!
+  primaryVehicle: Boolean!
+}
+
 type CustomerNode {
   firstName: String
   lastName: String
@@ -43,6 +48,7 @@ type CustomerNode {
   phoneNumber: String
   addressSecurityBan: Boolean
   driverLicenseChecked: Boolean
+  activePermits: [CustomerActivePermit]
 }
 
 type VehicleNode {
@@ -81,6 +87,7 @@ type PermitNode {
   endTime: String
   description: String
   type: String
+  primaryVehicle: Boolean!
 }
 
 type RefundNode {


### PR DESCRIPTION
Also we include active permits information in the GraphQL CustomerNode so that the frontend could fetch this information and do validation also.

Refs: PV-383