### PR TITLE
Implement csv exporter

### DIFF
--- a/parking_permits/exporters.py
+++ b/parking_permits/exporters.py
@@ -1,0 +1,152 @@
+from django.utils.translation import ugettext_lazy as _
+
+from parking_permits.models import Order, ParkingPermit, Product, Refund
+from parking_permits.utils import apply_filtering, apply_ordering
+
+DATETIME_FORMAT = "%-d.%-m.%Y, %H:%M"
+DATE_FORMAT = "%-d.%-m.%Y"
+
+MODEL_MAPPING = {
+    "permits": ParkingPermit,
+    "orders": Order,
+    "refunds": Refund,
+    "products": Product,
+}
+
+
+def _get_permit_row(permit):
+    customer = permit.customer
+    vehicle = permit.vehicle
+    name = f"{customer.last_name}, {customer.first_name}"
+    return [
+        name,
+        customer.national_id_number,
+        vehicle.registration_number,
+        str(customer.primary_address),
+        str(customer.other_address),
+        permit.parking_zone.name,
+        permit.start_time.strftime(DATETIME_FORMAT) if permit.start_time else "",
+        permit.end_time.strftime(DATETIME_FORMAT) if permit.end_time else "",
+        permit.get_status_display(),
+    ]
+
+
+def _get_order_row(order):
+    customer = order.customer
+    permit_ids = order.order_items.values_list("permit")
+    permits = ParkingPermit.objects.filter(id__in=permit_ids)
+    reg_numbers = ", ".join([permit.vehicle.registration_number for permit in permits])
+    name = f"{customer.last_name}, {customer.first_name}"
+    return [
+        name,
+        reg_numbers,
+        permits[0].parking_zone.name,
+        str(permits[0].address),
+        permits[0].get_type_display(),
+        order.order_number,
+        order.paid_time.strftime(DATETIME_FORMAT) if order.paid_time else "",
+        order.total_price,
+    ]
+
+
+def _get_refund_row(refund):
+    return [
+        refund.name,
+        refund.amount,
+        refund.iban,
+        refund.get_status_display(),
+        refund.created_at.strftime(DATETIME_FORMAT),
+    ]
+
+
+def _get_product_row(product):
+    start_date = product.start_date.strftime(DATE_FORMAT)
+    end_date = product.end_date.strftime(DATE_FORMAT)
+    valid_period = f"{start_date} - {end_date}"
+    return [
+        product.get_type_display(),
+        product.zone.name,
+        product.unit_price,
+        product.vat,
+        valid_period,
+        product.modified_at.strftime(DATETIME_FORMAT),
+        product.modified_by,
+    ]
+
+
+ROW_GETTER_MAPPING = {
+    "permits": _get_permit_row,
+    "orders": _get_order_row,
+    "refunds": _get_refund_row,
+    "products": _get_product_row,
+}
+
+PERMIT_HEADERS = [
+    _("Name"),
+    "Hetu",
+    _("Registration number"),
+    _("Permanent address"),
+    _("Temporary address"),
+    _("Parking zone"),
+    _("Start time"),
+    _("End time"),
+    _("Status"),
+]
+
+ORDER_HEADERS = [
+    _("Name"),
+    _("Registration number"),
+    _("Parking zone"),
+    _("Address"),
+    _("Permit type"),
+    _("Order number"),
+    _("Paid time"),
+]
+
+REFUND_HEADERS = [
+    _("Name"),
+    _("Amount"),
+    "IBAN",
+    _("Status"),
+    _("Created at"),
+]
+
+PRODUCT_HEADERS = [
+    _("Product type"),
+    _("Parking zone"),
+    _("Price"),
+    _("VAT"),
+    _("Valid period"),
+    _("Modified at"),
+    _("Modified by"),
+]
+
+HEADERS_MAPPING = {
+    "permits": PERMIT_HEADERS,
+    "orders": ORDER_HEADERS,
+    "refunds": REFUND_HEADERS,
+    "products": PRODUCT_HEADERS,
+}
+
+
+class DataExporter:
+    def __init__(self, data_type, order_by=None, search_items=None):
+        self.data_type = data_type
+        self.order_by = order_by
+        self.search_items = search_items
+
+    def get_queryset(self):
+        model_class = MODEL_MAPPING[self.data_type]
+        qs = model_class.objects.all()
+        if self.order_by:
+            qs = apply_ordering(qs, self.order_by)
+        if self.search_items:
+            qs = apply_filtering(qs, self.search_items)
+        return qs
+
+    def get_headers(self):
+        return HEADERS_MAPPING[self.data_type]
+
+    def get_rows(self):
+        row_getter = ROW_GETTER_MAPPING[self.data_type]
+        return [row_getter(item) for item in self.get_queryset()]

--- a/parking_permits/forms.py
+++ b/parking_permits/forms.py
@@ -1,0 +1,69 @@
+import json
+
+from django import forms
+from django.utils.translation import ugettext as _
+
+from parking_permits.utils import convert_to_snake_case
+
+EXPORT_DATA_TYPE_CHOICES = [
+    ("permits", "Permits"),
+    ("orders", "Orders"),
+    ("refunds", "Refunds"),
+    ("products", "Products"),
+]
+
+
+class DataExportForm(forms.Form):
+    data_type = forms.ChoiceField(choices=EXPORT_DATA_TYPE_CHOICES)
+    order_by = forms.CharField(required=False)
+    search_items = forms.CharField(required=False)
+
+    def _validate_order_by(self, order_by):
+        return (
+            isinstance(order_by, dict)
+            and order_by.get("order_fields")
+            and order_by.get("order_direction")
+        )
+
+    def clean_order_by(self):
+        value = self.cleaned_data.get("order_by")
+        if not value:
+            return None
+        try:
+            order_by = json.loads(value)
+            converted_order_by = convert_to_snake_case(order_by)
+            if self._validate_order_by(converted_order_by):
+                return converted_order_by
+            else:
+                raise forms.ValidationError(_("Invalid order by"), code="invalid_data")
+        except json.JSONDecodeError:
+            raise forms.ValidationError(_("Invalid order by"), code="decode_error")
+
+    def _validate_search_item(self, search_item):
+        return (
+            isinstance(search_item, dict)
+            and search_item.get("match_type")
+            and search_item.get("fields")
+            and search_item.get("value")
+        )
+
+    def clean_search_items(self):
+        value = self.cleaned_data.get("search_items")
+        if not value:
+            return None
+        try:
+            search_items = json.loads(value)
+            converted_search_items = convert_to_snake_case(search_items)
+            if all(
+                [
+                    self._validate_search_item(search_item)
+                    for search_item in converted_search_items
+                ]
+            ):
+                return converted_search_items
+            else:
+                raise forms.ValidationError(
+                    _("Invalid search items"), code="invalid_data"
+                )
+        except json.JSONDecodeError:
+            raise forms.ValidationError(_("Invalid search items"), code="decode_error")

--- a/parking_permits/tests/factories/order.py
+++ b/parking_permits/tests/factories/order.py
@@ -21,6 +21,7 @@ class OrderItemFactory(factory.django.DjangoModelFactory):
     product = factory.SubFactory(ProductFactory)
     permit = factory.SubFactory(ParkingPermitFactory)
     unit_price = Decimal(30)
+    payment_unit_price = Decimal(30)
     vat = Decimal(0.24)
     quantity = 6
 

--- a/parking_permits/tests/factories/refund.py
+++ b/parking_permits/tests/factories/refund.py
@@ -1,0 +1,16 @@
+from decimal import Decimal
+
+import factory
+
+from parking_permits.models import Refund
+from parking_permits.tests.factories.order import OrderFactory
+
+
+class RefundFactory(factory.django.DjangoModelFactory):
+    name = factory.Faker("name")
+    order = factory.SubFactory(OrderFactory)
+    amount = Decimal(50)
+    iban = "FI10000000000001111"
+
+    class Meta:
+        model = Refund

--- a/parking_permits/tests/test_exporters.py
+++ b/parking_permits/tests/test_exporters.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+
+from parking_permits.exporters import (
+    ORDER_HEADERS,
+    PERMIT_HEADERS,
+    PRODUCT_HEADERS,
+    REFUND_HEADERS,
+    DataExporter,
+)
+from parking_permits.tests.factories import ParkingZoneFactory
+from parking_permits.tests.factories.customer import CustomerFactory
+from parking_permits.tests.factories.order import OrderFactory, OrderItemFactory
+from parking_permits.tests.factories.parking_permit import ParkingPermitFactory
+from parking_permits.tests.factories.product import ProductFactory
+from parking_permits.tests.factories.refund import RefundFactory
+
+
+class DataExporterTestCase(TestCase):
+    def setUp(self):
+        self.customer_a = CustomerFactory(national_id_number="20000101-ABC")
+        self.customer_b = CustomerFactory(national_id_number="20000102-EFG")
+        self.zone_a = ParkingZoneFactory(name="A")
+        self.zone_b = ParkingZoneFactory(name="B")
+
+    def test_export_permits(self):
+        ParkingPermitFactory(customer=self.customer_a, parking_zone=self.zone_a)
+        ParkingPermitFactory(customer=self.customer_a, parking_zone=self.zone_b)
+        ParkingPermitFactory(customer=self.customer_b, parking_zone=self.zone_b)
+        order_by = {
+            "order_fields": ["customer__national_id_number"],
+            "order_direction": "DESC",
+        }
+        search_items = [
+            {"match_type": "exact", "fields": ["parking_zone__name"], "value": "B"}
+        ]
+        exporter = DataExporter("permits", order_by, search_items)
+        self.assertEqual(exporter.get_headers(), PERMIT_HEADERS)
+        rows = exporter.get_rows()
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0][1], "20000102-EFG")
+        self.assertEqual(rows[1][1], "20000101-ABC")
+
+    def test_export_orders(self):
+        order_1 = OrderFactory(customer=self.customer_a)
+        OrderItemFactory(order=order_1)
+        order_2 = OrderFactory(customer=self.customer_a)
+        OrderItemFactory(order=order_2)
+        order_3 = OrderFactory(customer=self.customer_b)
+        OrderItemFactory(order=order_3)
+        exporter = DataExporter("orders")
+        self.assertEqual(exporter.get_headers(), ORDER_HEADERS)
+        rows = exporter.get_rows()
+        self.assertEqual(len(rows), 3)
+
+    def test_export_refunds(self):
+        RefundFactory()
+        RefundFactory()
+        RefundFactory()
+        exporter = DataExporter("refunds")
+        self.assertEqual(exporter.get_headers(), REFUND_HEADERS)
+        rows = exporter.get_rows()
+        self.assertEqual(len(rows), 3)
+
+    def test_export_products(self):
+        ProductFactory()
+        ProductFactory()
+        ProductFactory()
+        exporter = DataExporter("products")
+        self.assertEqual(exporter.get_headers(), PRODUCT_HEADERS)
+        rows = exporter.get_rows()
+        self.assertEqual(len(rows), 3)

--- a/parking_permits/tests/test_forms.py
+++ b/parking_permits/tests/test_forms.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+
+from parking_permits.forms import DataExportForm
+
+
+class DataExportFormTestCase(TestCase):
+    def test_form_is_valid_when_valid_data_provided(self):
+        data = {
+            "data_type": "orders",
+            "order_by": '{"order_fields": ["order_number"], "order_direction": "DESC"}',
+            "search_items": '[{"matchType": "exact", "fields": ["order_number"], "value": 1}]',
+        }
+        form = DataExportForm(data)
+        self.assertTrue(form.is_valid())
+
+    def test_form_not_valid_when_fail_to_decode_error(self):
+        data = {"data_type": "orders", "order_by": ";{}"}
+        form = DataExportForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertTrue(form.has_error("order_by", code="decode_error"))
+
+    def test_form_not_valid_when_invalid_order_by_provided(self):
+        data = {"data_type": "orders", "order_by": '{"key": "value"}'}
+        form = DataExportForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertTrue(form.has_error("order_by", code="invalid_data"))
+
+    def test_form_not_valid_when_fail_to_decode_search_items(self):
+        data = {"data_type": "orders", "search_items": "[,]"}
+        form = DataExportForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertTrue(form.has_error("search_items", code="decode_error"))
+
+    def test_form_not_valid_when_invalid_search_items_provided(self):
+        data = {"data_type": "orders", "search_items": '[{"matchType": "exact"}]'}
+        form = DataExportForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertTrue(form.has_error("search_items", code="invalid_data"))

--- a/parking_permits/tests/test_reversion.py
+++ b/parking_permits/tests/test_reversion.py
@@ -1,7 +1,7 @@
 import datetime
 
 import reversion
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from parking_permits.models import ParkingPermit
 from parking_permits.models.parking_permit import ParkingPermitStatus
@@ -16,6 +16,7 @@ from parking_permits.tests.factories.parking_permit import ParkingPermitFactory
 from users.tests.factories.user import UserFactory
 
 
+@override_settings(LANGUAGE_CODE="en")
 class FieldChangeResolverTestCase(TestCase):
     def test_is_changed_return_true_for_time_diff_greater_than_1_millisecond(self):
         dt_1 = datetime.datetime(2021, 10, 1, 0, 0, 0, 0)

--- a/parking_permits/urls.py
+++ b/parking_permits/urls.py
@@ -31,4 +31,5 @@ urlpatterns = [
         views.ParkingPermitsGDPRAPIView.as_view(),
         name="gdpr_v1",
     ),
+    path("export", views.csv_export, name="export"),
 ]

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -2,6 +2,7 @@ import calendar
 import operator
 from functools import reduce
 
+from ariadne import convert_camel_case_to_snake
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
 from django.utils import timezone
@@ -80,3 +81,18 @@ def date_time_to_utc(dt):
     return (
         dt.replace(microsecond=0).astimezone(utc).replace(tzinfo=None).isoformat() + "Z"
     )
+
+
+def convert_to_snake_case(d):
+    if isinstance(d, str):
+        return convert_camel_case_to_snake(d)
+    if isinstance(d, list):
+        return [convert_to_snake_case(i) if isinstance(i, dict) else i for i in d]
+    if isinstance(d, dict):
+        converted = {}
+        for k, v in d.items():
+            if isinstance(v, (dict, list)):
+                v = convert_to_snake_case(v)
+            converted[convert_camel_case_to_snake(k)] = v
+        return converted
+    return d


### PR DESCRIPTION
This PR implements a csv exporter for permits, refunds, orders and products. The export view is authenticated using the same JWT token obtained from Tunnistamo. The data can be ordered and filtered by passing `order_by` and `search_items` parameters to the URL.

Refs: PV-351