### PR TITLE
Refactor permit price calculation for Admin UI

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -234,22 +234,6 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         return self.start_time + relativedelta(months=self.months_used)
 
     @property
-    def monthly_price(self):
-        """
-        Return the monthly price for current period
-
-        Current monthly price is determined by the start date of current period
-        """
-        period_start_date = timezone.localdate(self.current_period_start_time)
-        product = self.parking_zone.products.for_resident().get_for_date(
-            period_start_date
-        )
-        is_secondary = not self.primary_vehicle
-        return product.get_modified_unit_price(
-            self.vehicle.is_low_emission, is_secondary
-        )
-
-    @property
     def can_be_refunded(self):
         return self.is_valid and self.is_fixed_period
 

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -19,7 +19,7 @@ from ..exceptions import (
     PermitCanNotBeEnded,
     RefundError,
 )
-from ..utils import diff_months_ceil, get_end_time
+from ..utils import diff_months_ceil, get_end_time, get_permit_prices
 from .mixins import TimestampedModelMixin
 from .parking_zone import ParkingZone
 from .vehicle import Vehicle
@@ -183,6 +183,20 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
     def latest_order_items(self):
         """Get latest order items for the permit"""
         return self.order_items.filter(order=self.latest_order)
+
+    @property
+    def permit_prices(self):
+        if self.is_fixed_period:
+            end_time = self.end_time
+        else:
+            end_time = get_end_time(self.start_time, 1)
+        return get_permit_prices(
+            self.parking_zone,
+            self.vehicle.is_low_emission,
+            not self.primary_vehicle,
+            self.start_time.date(),
+            end_time.date(),
+        )
 
     @property
     def is_valid(self):

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -12,11 +12,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from helsinki_gdpr.models import SerializableMixin
 
-from ..constants import (
-    LOW_EMISSION_DISCOUNT,
-    SECONDARY_VEHICLE_PRICE_INCREASE,
-    ParkingPermitEndType,
-)
+from ..constants import ParkingPermitEndType
 from ..exceptions import (
     InvalidContractType,
     ParkkihubiPermitError,
@@ -168,26 +164,6 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
     @property
     def consent_low_emission_accepted(self):
         return self.vehicle.consent_low_emission_accepted
-
-    def get_prices(self):
-        # TODO: account for different prices in different years
-        logger.error(
-            "To be removed. This method is replaced by get_products_with_quantities"
-        )
-        monthly_price = self.parking_zone.resident_price
-        month_count = self.month_count
-
-        if self.contract_type == ContractType.OPEN_ENDED:
-            month_count = 1
-        if self.is_secondary_vehicle:
-            increase = Decimal(SECONDARY_VEHICLE_PRICE_INCREASE) / 100
-            monthly_price += increase * monthly_price
-
-        if self.vehicle.is_low_emission:
-            discount = Decimal(LOW_EMISSION_DISCOUNT) / 100
-            monthly_price -= discount * monthly_price
-
-        return monthly_price * month_count, monthly_price
 
     @property
     def latest_order(self):

--- a/parking_permits/models/parking_zone.py
+++ b/parking_permits/models/parking_zone.py
@@ -6,9 +6,7 @@ from django.contrib.gis.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from ..exceptions import PriceError
 from .mixins import TimestampedModelMixin
-from .price import Price, PriceType
 
 logger = logging.getLogger("db")
 
@@ -40,29 +38,6 @@ class ParkingZone(TimestampedModelMixin):
     @property
     def label_sv(self):
         return f"{self.name} - {self.description_sv}"
-
-    @property
-    def price(self):
-        logger.error("To be removed. This property should not be used anymore.")
-        return self.resident_price
-
-    @property
-    def resident_price(self):
-        logger.error("To be removed. This property should not be used anymore.")
-        try:
-            price = self.prices.get(type=PriceType.RESIDENT, year=timezone.now().year)
-        except Price.DoesNotExist:
-            raise PriceError("No resident price available")
-        return price.price
-
-    @property
-    def company_price(self):
-        logger.error("To be removed. This property should not be used anymore.")
-        try:
-            price = self.prices.get(type=PriceType.COMPANY, year=timezone.now().year)
-        except Price.DoesNotExist:
-            raise PriceError("No company price available")
-        return price.price
 
     @property
     def resident_products(self):

--- a/parking_permits/models/vehicle.py
+++ b/parking_permits/models/vehicle.py
@@ -105,6 +105,10 @@ class Vehicle(TimestampedModelMixin):
     )
     users = ArrayField(models.CharField(max_length=15), default=list)
 
+    class Meta:
+        verbose_name = _("Vehicle")
+        verbose_name_plural = _("Vehicles")
+
     def is_due_for_inspection(self):
         return (
             self.last_inspection_date is not None
@@ -138,10 +142,6 @@ class Vehicle(TimestampedModelMixin):
             return self.emission <= le_criteria.wltp_max_emission_limit
 
         return False
-
-    class Meta:
-        verbose_name = _("Vehicle")
-        verbose_name_plural = _("Vehicles")
 
     def __str__(self):
         return "%s (%s, %s)" % (

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -197,6 +197,7 @@ type PermitDetailNode {
   canEndAfterCurrentPeriod: Boolean
   canBeRefunded: Boolean
   changeLogs: [ChangeLog]!
+  permitPrices: [PermitPriceNode]
 }
 
 type PermitPriceChange {

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -182,6 +182,7 @@ type PermitDetailNode {
   id: ID!
   customer: CustomerNode!
   vehicle: VehicleNode
+  primaryVehicle: Boolean!
   parkingZone: ZoneNode
   status: ParkingPermitStatus!
   startTime: String
@@ -224,6 +225,14 @@ type PagedLowEmissionCriteria {
   pageInfo: PageInfo
 }
 
+type PermitPriceNode {
+  originalUnitPrice: Float!
+  unitPrice: Float!
+  startDate: String!
+  endDate: String!
+  quantity: Int!
+}
+
 type Query {
   permits(
     pageInput: PageInput!
@@ -260,6 +269,7 @@ type Query {
     orderBy: OrderByInput
   ): PagedLowEmissionCriteria!
   lowEmissionCriterion(criterionId: ID!): LowEmissionCriterionNode!
+  permitPrices(permit: ResidentPermitInput!, isSecondary: Boolean!): [PermitPriceNode]!
 }
 
 input AddressInput {

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -191,7 +191,6 @@ type PermitDetailNode {
   contractType: String
   monthCount: Int
   monthsLeft: Int
-  monthlyPrice: Float
   currentPeriodEndTime: String
   canEndImmediately: Boolean
   canEndAfterCurrentPeriod: Boolean

--- a/parking_permits/tests/models/test_zone.py
+++ b/parking_permits/tests/models/test_zone.py
@@ -1,32 +1,16 @@
 from datetime import date
-from decimal import Decimal
 
 from django.test import TestCase, override_settings
 from freezegun import freeze_time
 
-from parking_permits.exceptions import PriceError
 from parking_permits.models.product import ProductType
-from parking_permits.tests.factories import ParkingZoneFactory, PriceFactory
+from parking_permits.tests.factories import ParkingZoneFactory
 from parking_permits.tests.factories.product import ProductFactory
 
 
 class ParkingZoneTestCase(TestCase):
     def setUp(self):
         self.zone = ParkingZoneFactory()
-
-    @freeze_time("2021-10-16")
-    def test_zone_price_return_correct_price(self):
-        PriceFactory(
-            zone=self.zone,
-            price=Decimal(20),
-            year=2021,
-        )
-        self.assertEqual(self.zone.resident_price, Decimal(20))
-
-    @freeze_time("2021-10-16")
-    def test_zone_price_raise_price_error_if_no_price_defined(self):
-        with self.assertRaises(PriceError):
-            self.zone.resident_price
 
     @freeze_time("2021-12-20")
     @override_settings(DBUG=True)

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -96,3 +96,33 @@ def convert_to_snake_case(d):
             converted[convert_camel_case_to_snake(k)] = v
         return converted
     return d
+
+
+def get_permit_prices(
+    zone,
+    is_low_emission,
+    is_secondary,
+    permit_start_date,
+    permit_end_date,
+):
+    products = zone.products.for_resident().for_date_range(
+        permit_start_date,
+        permit_end_date,
+    )
+    permit_prices = []
+    for product in products:
+        start_date = max(product.start_date, permit_start_date)
+        end_date = min(product.end_date, permit_end_date)
+        quantity = diff_months_ceil(start_date, end_date)
+        permit_prices.append(
+            {
+                "original_unit_price": product.unit_price,
+                "unit_price": product.get_modified_unit_price(
+                    is_low_emission, is_secondary
+                ),
+                "start_date": start_date,
+                "end_date": end_date,
+                "quantity": quantity,
+            }
+        )
+    return permit_prices


### PR DESCRIPTION
Previously we were using a checkbox to determine if a vehicle is a low emission one or not, this simplifies the process for displaying permit prices to the admin as we could fetch the product prices from the backend and do the calculation based on the value of the low emission checkbox.

This is changed due to the addition of the low emission-related fields. The checkbox is replaced with several low emission fields and needs to query the low emission criteria model to determine if the vehicle is a low emission one.

This PR adds a resolver to gather the price info from the unsaved permit, and also a property in the permit to return the price info of the saved permit.

Refs: PV-387, PV-384