### PR TITLE
Refactor the search filters

### DIFF
--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -164,9 +164,14 @@ input OrderByInput {
   orderDirection: OrderDirection!
 }
 
-input SearchItem {
+input SearchField {
   matchType: String!
-  fields: [String]!
+  fieldName: String!
+}
+
+input SearchItem {
+  connector: String!
+  fields: [SearchField]!
   value: String!
 }
 

--- a/parking_permits/tests/test_exporters.py
+++ b/parking_permits/tests/test_exporters.py
@@ -31,7 +31,11 @@ class DataExporterTestCase(TestCase):
             "order_direction": "DESC",
         }
         search_items = [
-            {"match_type": "exact", "fields": ["parking_zone__name"], "value": "B"}
+            {
+                "connector": "and",
+                "fields": [{"match_type": "exact", "field_name": "parking_zone__name"}],
+                "value": "B",
+            }
         ]
         exporter = DataExporter("permits", order_by, search_items)
         self.assertEqual(exporter.get_headers(), PERMIT_HEADERS)

--- a/parking_permits/tests/test_utils.py
+++ b/parking_permits/tests/test_utils.py
@@ -65,13 +65,21 @@ class ApplyingFilteringTestCase(TestCase):
     def test_search_with_model_fields(self):
         all_parking_permits = ParkingPermit.objects.all()
         search_items = [
-            {"match_type": "iexact", "fields": ["status"], "value": "VALID"}
+            {
+                "connector": "and",
+                "fields": [{"match_type": "iexact", "field_name": "status"}],
+                "value": "VALID",
+            }
         ]
         qs = apply_filtering(all_parking_permits, search_items)
         self.assertEqual(qs.count(), 1)
 
         search_items = [
-            {"match_type": "iexact", "fields": ["status"], "value": "DRAFT"}
+            {
+                "connector": "and",
+                "fields": [{"match_type": "iexact", "field_name": "status"}],
+                "value": "DRAFT",
+            }
         ]
         qs = apply_filtering(all_parking_permits, search_items)
         self.assertEqual(qs.count(), 2)
@@ -80,8 +88,11 @@ class ApplyingFilteringTestCase(TestCase):
         all_parking_permits = ParkingPermit.objects.all()
         search_items = [
             {
-                "match_type": "istartswith",
-                "fields": ["customer__first_name", "customer__last_name"],
+                "connector": "or",
+                "fields": [
+                    {"match_type": "istartswith", "field_name": "customer__first_name"},
+                    {"match_type": "istartswith", "field_name": "customer__last_name"},
+                ],
                 "value": "last",
             }
         ]
@@ -90,8 +101,11 @@ class ApplyingFilteringTestCase(TestCase):
 
         search_items = [
             {
-                "match_type": "iexact",
-                "fields": ["customer__first_name", "customer__last_name"],
+                "connector": "or",
+                "fields": [
+                    {"match_type": "istartswith", "field_name": "customer__first_name"},
+                    {"match_type": "istartswith", "field_name": "customer__last_name"},
+                ],
                 "value": "Firstname A",
             }
         ]
@@ -102,11 +116,18 @@ class ApplyingFilteringTestCase(TestCase):
         all_parking_permits = ParkingPermit.objects.all()
         search_items = [
             {
-                "match_type": "iexact",
-                "fields": ["customer__first_name", "customer__last_name"],
+                "connector": "or",
+                "fields": [
+                    {"match_type": "istartswith", "field_name": "customer__first_name"},
+                    {"match_type": "istartswith", "field_name": "customer__last_name"},
+                ],
                 "value": "firstname a",
             },
-            {"match_type": "iexact", "fields": ["status"], "value": "DRAFT"},
+            {
+                "connector": "and",
+                "fields": [{"match_type": "iexact", "field_name": "status"}],
+                "value": "DRAFT",
+            },
         ]
         qs = apply_filtering(all_parking_permits, search_items)
         self.assertEqual(qs.count(), 1)

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -19,13 +19,20 @@ def apply_ordering(queryset, order_by):
 
 def apply_filtering(queryset, search_items):
     query = Q()
+    connector_ops = {
+        "or": operator.or_,
+        "and": operator.and_,
+    }
     for search_item in search_items:
-        match_type = search_item["match_type"]
+        connector = search_item["connector"]
         fields = search_item["fields"]
         value = search_item["value"]
-        search_item_query = reduce(
-            operator.or_, [Q(**{f"{field}__{match_type}": value}) for field in fields]
-        )
+        connector_op = connector_ops[connector]
+        field_queries = []
+        for field in fields:
+            field_query = Q(**{f'{field["field_name"]}__{field["match_type"]}': value})
+            field_queries.append(field_query)
+        search_item_query = reduce(connector_op, field_queries)
         query &= search_item_query
     return queryset.filter(query)
 


### PR DESCRIPTION
There is a need (in permits and orders) to search against multiple fields.
These searches should be or-ed together

Refs: PV-400