### PR TITLE
Fix low emissin calculation when emission is 0

### DIFF
--- a/parking_permits/models/vehicle.py
+++ b/parking_permits/models/vehicle.py
@@ -55,7 +55,11 @@ def is_low_emission_vehicle(power_type, euro_class, emission_type, emission):
     except LowEmissionCriteria.DoesNotExist:
         return False
 
-    if not euro_class or not emission or euro_class < le_criteria.euro_min_class_limit:
+    if (
+        not euro_class
+        or emission is None
+        or euro_class < le_criteria.euro_min_class_limit
+    ):
         return False
 
     if emission_type == EmissionType.NEDC:


### PR DESCRIPTION
Previously 0 emission are treated the same (i.e. return False) as null
value