### PR TITLE
Feat/pv 420 address maintenance

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -29,7 +29,6 @@ from parking_permits.models import (
 
 from .decorators import is_ad_admin
 from .exceptions import (
-    AddressError,
     CreatePermitError,
     ObjectNotFound,
     ParkingZoneError,
@@ -146,13 +145,13 @@ def resolve_vehicle(obj, info, reg_number, national_id_number):
 
 
 def create_address(address_info):
-    location = Point(*address_info["location"], srid=settings.SRID)
     address_obj = Address.objects.update_or_create(
         street_name=address_info["street_name"],
         street_number=address_info["street_number"],
         city=address_info["city"],
         postal_code=address_info["postal_code"],
-        defaults=address_info)
+        defaults=address_info,
+    )
     return address_obj[0]
 
 

--- a/parking_permits/exceptions.py
+++ b/parking_permits/exceptions.py
@@ -84,3 +84,7 @@ class DVVIntegrationError(ParkingPermitBaseException):
 
 class SearchError(ParkingPermitBaseException):
     pass
+
+
+class LocationDoesNotExist(ParkingPermitBaseException):
+    pass

--- a/parking_permits/models/address.py
+++ b/parking_permits/models/address.py
@@ -5,9 +5,9 @@ from django.contrib.gis.db import models
 from django.utils.translation import gettext_lazy as _
 from helsinki_gdpr.models import SerializableMixin
 
+from ..exceptions import LocationDoesNotExist
 from .mixins import TimestampedModelMixin
 from .parking_zone import ParkingZone
-from ..exceptions import LocationDoesNotExist
 
 logger = logging.getLogger("db")
 
@@ -52,7 +52,7 @@ class Address(SerializableMixin, TimestampedModelMixin):
     @property
     def zone(self):
         if not self.location:
-            raise LocationDoesNotExist('Location is not set')
+            raise LocationDoesNotExist("Location is not set")
         try:
             self._zone = ParkingZone.objects.get_for_location(self.location)
             self.save()

--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -71,9 +71,10 @@ def save_profile_address(address):
     address_obj = Address.objects.update_or_create(
         street_name=street_name,
         street_number=street_number,
-        city=address['city'],
-        postal_code=address['postal_code'],
-        defaults=address)
+        city=address["city"],
+        postal_code=address["postal_code"],
+        defaults=address,
+    )
     return address_obj[0]
 
 

--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -68,8 +68,13 @@ def save_profile_address(address):
     street_number = address.get("street_number")
     address_detail = get_address_detail_from_kmo(street_name, street_number)
     address.update(address_detail)
-    address_obj = Address.objects.create(**address)
-    return address_obj
+    address_obj = Address.objects.update_or_create(
+        street_name=street_name,
+        street_number=street_number,
+        city=address['city'],
+        postal_code=address['postal_code'],
+        defaults=address)
+    return address_obj[0]
 
 
 @query.field("profile")

--- a/parking_permits/schema/parking_permit.graphql
+++ b/parking_permits/schema/parking_permit.graphql
@@ -9,7 +9,7 @@ type ZoneNode  {
 type AddressNode  {
   id: ID!
   streetName: String
-  streetNumber: Int
+  streetNumber: String
   streetNameSv: String
   city: String
   citySv: String

--- a/parking_permits/services/kmo.py
+++ b/parking_permits/services/kmo.py
@@ -7,7 +7,11 @@ from django.contrib.gis.geos import GEOSGeometry
 from rest_framework import status
 
 
-def get_wfs_result(street_name="", street_number=0):
+def get_wfs_result(street_name="", street_number_token=""):
+    street_number_first_part = re.search(r"^\d+", street_number_token)
+    street_number = (
+        int(street_number_first_part.group()) if street_number_first_part else 0
+    )
     street_address = f"katunimi=''{street_name}'' AND osoitenumero=''{street_number}''"
     query_single_args = [
         "'avoindata:Helsinki_osoiteluettelo'",
@@ -59,15 +63,12 @@ def get_wfs_result(street_name="", street_number=0):
 def parse_street_name_and_number(street_address):
     tokens = street_address.split()
 
-    street_name = tokens[0] if len(tokens) >= 1 else None
-    street_number_token = tokens[1] if len(tokens) >= 2 else ""
+    street_name = tokens[0] if len(tokens) >= 1 else ""
 
-    street_number_first_part = re.search(r"^\d+", street_number_token)
-    street_number = (
-        int(street_number_first_part.group()) if street_number_first_part else None
+    return dict(
+        street_name=street_name,
+        street_number=" ".join(tokens[1:]) if len(tokens) else "",
     )
-
-    return dict(street_name=street_name, street_number=street_number)
 
 
 def get_address_detail_from_kmo(street_name, street_number):

--- a/parking_permits/services/kmo_tests.py
+++ b/parking_permits/services/kmo_tests.py
@@ -6,12 +6,12 @@ from parking_permits.services.kmo import parse_street_name_and_number
 @pytest.mark.parametrize(
     "street_address, street_name, street_number",
     [
-        ("", None, None),
-        ("Mannerheimintie", "Mannerheimintie", None),
-        ("Mannerheimintie 2", "Mannerheimintie", 2),
-        ("Mannerheimintie 4-5", "Mannerheimintie", 4),
-        ("Mannerheimintie 21-24", "Mannerheimintie", 21),
-        ("Mannerheimintie 30,32", "Mannerheimintie", 30),
+        ("", "", ""),
+        ("Mannerheimintie", "Mannerheimintie", ""),
+        ("Mannerheimintie 2", "Mannerheimintie", "2"),
+        ("Mannerheimintie 4-5", "Mannerheimintie", "4-5"),
+        ("Mannerheimintie 2 A 7", "Mannerheimintie", "2 A 7"),
+        ("Mannerheimintie 30,32", "Mannerheimintie", "30,32"),
     ],
 )
 def test_parse_street_name_and_number_function_returns_correct_result(

--- a/parking_permits/tests/factories/address.py
+++ b/parking_permits/tests/factories/address.py
@@ -13,7 +13,7 @@ class AddressFactory(factory.django.DjangoModelFactory):
     city_sv = factory.Faker("city", locale="sv")
     postal_code = factory.Faker("postcode")
     _zone = factory.SubFactory(ParkingZoneFactory)
-    location = factory.SelfAttribute('_zone.location.centroid')
+    location = factory.SelfAttribute("_zone.location.centroid")
 
     class Meta:
         model = Address

--- a/parking_permits/tests/factories/address.py
+++ b/parking_permits/tests/factories/address.py
@@ -1,5 +1,4 @@
 import factory
-from django.contrib.gis.geos import Point
 
 from parking_permits.models import Address
 
@@ -13,8 +12,8 @@ class AddressFactory(factory.django.DjangoModelFactory):
     city = factory.Faker("city", locale="fi")
     city_sv = factory.Faker("city", locale="sv")
     postal_code = factory.Faker("postcode")
-    location = Point(10000, 10000)
     _zone = factory.SubFactory(ParkingZoneFactory)
+    location = factory.SelfAttribute('_zone.location.centroid')
 
     class Meta:
         model = Address


### PR DESCRIPTION
* Move logic of street number separation to kmo
* Fix tests to use location of address as one of the zone center
* Update resolver so that it doesn't create a duplicate address from webshop
* Update resolver so that it doesn't create a duplicate address from admin
* Use zone as a calculative property
* Update street address type to string as its charField
* Add LocationDoesNotExists exception