### PR TITLE
Force Subscription registering process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG LOCAL_REDHAT_PASSWORD
 ARG BUILD_MODE
 
 # Copy entitlements
-COPY ./etc-pki-entitlement /etc/pki/entitlement
+COPY ./etc-pki-entitlement* /etc/pki/entitlement
 # Copy subscription manager configurations if required
 #COPY ./rhsm-conf /etc/rhsm
 #COPY ./rhsm-ca /etc/rhsm/ca

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY ./etc-pki-entitlement* /etc/pki/entitlement
 
 RUN if [ "x$BUILD_MODE" = "xlocal" ] ;\
     then \
-        subscription-manager register --username $LOCAL_REDHAT_USERNAME --password $LOCAL_REDHAT_PASSWORD --auto-attach; \
+        subscription-manager register --force --username $LOCAL_REDHAT_USERNAME --password $LOCAL_REDHAT_PASSWORD --auto-attach; \
     else \
         # subscription-manager register --username ${REDHAT_USERNAME} --password ${REDHAT_PASSWORD} --auto-attach; \
         yum repolist --disablerepo=*; \


### PR DESCRIPTION
## Description

Current CI occasionally fails in the RedHat subscription registering process.
This PR ateempts to fix it by using a `force`-flag to force subscription de-registering and registering process always, this it should remedy the current problem permanently.

## How Has This Been Tested?

Need to test this with Azure DevOps CI to make sure it is working.