### PR TITLE
Remove unneeded .gitconfig-declarations

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,2 +1,0 @@
-[safe]
-    directory = /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM ubuntu:20.04
 
-# Fixes git vulnerability issue in openshift
-COPY .gitconfig .
-# Fixes git vulnerability issue locally
-COPY .gitconfig /etc/gitconfig
-
 WORKDIR /app
 
 RUN apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false update && \


### PR DESCRIPTION
## Description

Remove unneeded .gitconfig-declarations. We don't need them right now.