### PR TITLE
Update address extractor and exclude saving it to database if not in Helsinki

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -110,9 +110,12 @@ class CustomerPermit:
     def get(self):
         permits = []
         # Delete all the draft permits if it wasn't created today
-        self.customer_permit_query.filter(
+        draft_permits = self.customer_permit_query.filter(
             status=DRAFT, start_time__lt=tz.localdate(tz.now())
-        ).delete()
+        ).all()
+        for permit in draft_permits:
+            permit.order_items.all().delete()
+            permit.delete()
 
         for permit in self.customer_permit_query.order_by("start_time"):
             permit.temporary_vehicles.filter(end_time__lt=tz.now()).update(

--- a/parking_permits/services/kmo.py
+++ b/parking_permits/services/kmo.py
@@ -61,13 +61,17 @@ def get_wfs_result(street_name="", street_number_token=""):
 
 
 def parse_street_name_and_number(street_address):
-    tokens = street_address.split()
+    index_of_street_number = 0
+    for character in street_address:
+        if character.isdigit():
+            index_of_street_number = street_address.index(character)
+            break
 
-    street_name = tokens[0] if len(tokens) >= 1 else ""
-
+    street_name = street_address[:index_of_street_number].strip()
+    street_number = street_address[index_of_street_number:].strip()
     return dict(
         street_name=street_name,
-        street_number=" ".join(tokens[1:]) if len(tokens) else "",
+        street_number=street_number,
     )
 
 


### PR DESCRIPTION
## Description

We should not save any user address that is not in Helsinki to parking permit database.
In this way we will eliminate the need of checking the validity of address every time we pull it also since the address will be null our frontend will automatically handles the case and show the proper notification to the user.

## Context

[PV-58](https://helsinkisolutionoffice.atlassian.net/browse/pv-58)

## How Has This Been Tested?

Tested using the following users
[Test users](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/PV/pages/7943618561/Webshop+testing)

## Manual Testing Instructions for Reviewers

Can be tested with these users:
[Test users](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/PV/pages/7943618561/Webshop+testing)

