### PR TITLE
PV-402: Return only distinct orders

### DIFF
--- a/parking_permits/forms.py
+++ b/parking_permits/forms.py
@@ -259,7 +259,7 @@ class OrderSearchForm(SearchFormBase):
         if "LOW_EMISSION" in price_discounts:
             qs = qs.filter(permits__vehicle___is_low_emission=True)
 
-        return qs
+        return qs.distinct("pk")
 
 
 class ProductSearchForm(SearchFormBase):


### PR DESCRIPTION
## Description

Turns out the API can return duplicate orders if you have any search parameters related to parking permits. This PR makes it return only distinct orders.

## Context

This should only return distinct orders, i.e. no duplicate orders.

[PV-402](https://helsinkisolutionoffice.atlassian.net/browse/PV-402)

## How Has This Been Tested?

Through a unit test.

## Manual Testing Instructions for Reviewers

No manual testing required, but if you want, you can try querying an order that has multiple parking permits and by filtering on a property related to the permits, e.g. parking zone name, start/end date.

## Screenshots

No screenshots.
