### PR TITLE
Retrieve both user addresses from DVV

### DIFF
--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -16,7 +16,7 @@ def automatic_expiration_of_permits():
 
 
 def automatic_remove_obsolete_customer_data():
-    logger.info("Automatically removing obsolte customer data started...")
+    logger.info("Automatically removing obsolete customer data started...")
     qs = Customer.objects.all()
     count = 0
     for customer in qs:
@@ -24,7 +24,7 @@ def automatic_remove_obsolete_customer_data():
             customer.delete_all_data()
             count += 1
     logger.info(
-        "Automatically removing obsolte customer data completed. "
+        "Automatically removing obsolete customer data completed. "
         f"{count} customers are removed."
     )
 

--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -26,7 +26,7 @@ from .models import Address, Customer, Refund, Vehicle
 from .models.order import Order, OrderStatus
 from .models.parking_permit import ContractType, ParkingPermit, ParkingPermitStatus
 from .services.hel_profile import HelsinkiProfile
-from .services.kmo import get_address_detail_from_kmo
+from .services.kmo import get_address_details
 from .services.mail import (
     PermitEmailType,
     RefundEmailType,
@@ -72,7 +72,7 @@ def resolve_customer_permits(obj, info):
 def save_profile_address(address):
     street_name = address.get("street_name")
     street_number = address.get("street_number")
-    address_detail = get_address_detail_from_kmo(street_name, street_number)
+    address_detail = get_address_details(street_name, street_number)
     address.update(address_detail)
     address_obj = Address.objects.update_or_create(
         street_name=street_name,


### PR DESCRIPTION
## Description

At the moment user address and area searching is a complicated thing as user addresses can be found from Helsinki profile verified information and also directly from a separate DVV-integration. Also address / area resolving is done differently in these two.

This PR simplifies the logic: find both addresses directly from DVV using user social security number that is given after successful Suomi.fi-login process. Also area search is simplified as a result of this.

If the address is not found from the KMO directly, then try to use own address master for this (as admins need to manually create missing addresses by design).

Refs:
- [PV-386](https://helsinkisolutionoffice.atlassian.net/browse/PV-386)
- [PV-446](https://helsinkisolutionoffice.atlassian.net/browse/PV-446)

## Manual Testing Instructions for Reviewers

Test with current test-users: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/PV/pages/7943618561/Webshop+testing
