### PR TITLE
Add is is_order_confirmed calculated property to parking permit

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -169,6 +169,13 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         return self.temp_vehicles.all()
 
     @property
+    def is_order_confirmed(self):
+        if self.orders:
+            recent_order = self.orders.order_by("-paid_time").first()
+            return recent_order.status == "CONFIRMED"
+        return False
+
+    @property
     def active_temporary_vehicle(self):
         return self.temporary_vehicles.filter(is_active=True).first()
 

--- a/parking_permits/schema/parking_permit.graphql
+++ b/parking_permits/schema/parking_permit.graphql
@@ -86,6 +86,7 @@ type PermitNode {
   hasRefund: Boolean
   vehicleChanged: Boolean
   zoneChanged: Boolean
+  isOrderConfirmed: Boolean
 }
 
 type PermitPriceChangeItem {


### PR DESCRIPTION
## Description

This property is used to know if the last order related to the permit has been paid or not.

## Context

In the web shop when the user has created a Talpa order and has been through the successful payment. Talpa needs to send a notification to our backend about the payment paid after which the order is marked as confirmed.  And once the permit is confirmed, it's send to Parkkihubi and marked as `VALID`. But sometimes sending to Parkkihubi fails and the status of the permit is left as `DRAFT` which results in a situation that user have to go through the payment process again. 

So we need to send the payment info to the frontend so that the UI can put the permit to a state where user don't need to pay again and rather wait for the system to get updated.

[PV-450](https://helsinkisolutionoffice.atlassian.net/browse/PV-450)

## Screenshots
<img width="999" alt="Screenshot 2022-10-06 at 8 27 34" src="https://user-images.githubusercontent.com/9328930/194223413-8ce8755a-a258-4118-965d-8c2047368710.png">


