### PR TITLE
Add management command for creating group mapping

### DIFF
--- a/parking_permits/management/commands/bootstrap_parking_permits.py
+++ b/parking_permits/management/commands/bootstrap_parking_permits.py
@@ -32,3 +32,4 @@ class Command(BaseCommand):
             "create_low_emission_criteria",
             year=2023,
         )
+        call_command("create_group_mapping")

--- a/parking_permits/management/commands/create_group_mapping.py
+++ b/parking_permits/management/commands/create_group_mapping.py
@@ -1,0 +1,96 @@
+from django.contrib.auth.models import Group, Permission
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from helusers.models import ADGroup, ADGroupMapping
+
+CONTENT_TYPE = "parking_permits"
+GROUPS = [
+    {
+        "name": "super_admin",
+        "ad_group": "sg_kymp_pyva_asukpt_yllapito",
+        "permissions": [
+            "add_product",
+            "change_product",
+            "delete_product",
+            "view_product",
+            "add_lowemissioncriteria",
+            "change_lowemissioncriteria",
+            "delete_lowemissioncriteria",
+            "view_lowemissioncriteria",
+            "add_address",
+            "change_address",
+            "delete_address",
+            "view_address",
+        ],
+    },
+    {
+        "name": "sanctions_and_returns",
+        "ad_group": "sg_kymp_pyva_asukpt_maksuseuraamukset_palautukset",
+        "permissions": [
+            "change_refund",
+        ],
+    },
+    {
+        "name": "sanctions",
+        "ad_group": "sg_kymp_pyva_asukpt_maksuseuraamukset",
+        "permissions": [
+            "change_refund",
+        ],
+    },
+    {
+        "name": "customer_service",
+        "ad_group": "sg_kymp_pyva_asukpt_asiakaspalvelu",
+        "permissions": [
+            "add_parkingpermit",
+            "change_parkingpermit",
+            "delete_parkingpermit",
+            "view_parkingpermit",
+            "change_refund",
+            "delete_refund",
+            "view_refund",
+        ],
+    },
+    {
+        "name": "preparators",
+        "ad_group": "sg_kymp_pyva_asukpt_valmistelijat",
+        "permissions": [
+            "view_parkingpermit",
+            "view_order",
+            "view_refund",
+        ],
+    },
+    {
+        "name": "inspectors",
+        "ad_group": "sg_kymp_pyva_asukpt_tarkastajat",
+        "permissions": [
+            "view_parkingpermit",
+        ],
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Create parking permit group and ad group mapping"
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        for group in GROUPS:
+            ad_group = ADGroup.objects.get_or_create(
+                name=group["ad_group"],
+                display_name=group["ad_group"],
+            )
+            parking_permit_group = Group.objects.get_or_create(
+                name=group["name"],
+            )
+            parking_permit_group[0].permissions.add(
+                *Permission.objects.filter(
+                    codename__in=group["permissions"],
+                    content_type__app_label=CONTENT_TYPE,
+                )
+            )
+
+            ADGroupMapping.objects.get_or_create(
+                group=parking_permit_group[0],
+                ad_group=ad_group[0],
+            )
+        self.stdout.write("Test Group and GroupMapping created")

--- a/parking_permits/tests/test_create_group_mapping_management_commands.py
+++ b/parking_permits/tests/test_create_group_mapping_management_commands.py
@@ -1,0 +1,15 @@
+import pytest
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+from helusers.models import ADGroup, ADGroupMapping
+
+from ..management.commands import create_group_mapping
+
+
+@pytest.mark.django_db
+def test_create_group_mapping():
+    call_command(create_group_mapping.Command())
+
+    assert ADGroup.objects.count() == 6
+    assert ADGroupMapping.objects.count() == 6
+    assert Group.objects.count() == 6


### PR DESCRIPTION
## Description

Add management command for creating django group, Ad group and a mapping between them.

## Context
[PV-448](https://helsinkisolutionoffice.atlassian.net/browse/PV-448)

1. super_admin (AD-group: sg_kymp_pyva_asukpt_yllapito)

    - Can create/update/delete Products
    - Can create/update/delete LowEmissionCriterias
    - Can create/update/delete Addresses
    - Can create/update/delete Announcements

2. sanctions_and_returns (AD-group: sg_kymp_pyva_asukpt_maksuseuraamukset_palautukset)

    - Can update Refunds

3. sanctions (AD-group: sg_kymp_pyva_asukpt_maksuseuraamukset)

    - Can update Refunds

4. customer_service (AD-group: sg_kymp_pyva_asukpt_asiakaspalvelu)

    - Can create/update/delete ParkingPermits
    - Can update/delete Refunds

5. preparators (AD-group: sg_kymp_pyva_asukpt_valmistelijat)

    - Can read ParkingPermits
    - Can read Orders
    - Can read Refunds

.6 inspectors (AD-group: sg_kymp_pyva_asukpt_tarkastajat)

    - Can read ParkingPermits

## How Has This Been Tested?

Log in to admin panel and you can see the list under Adgroup and Adgroup mappings

## Manual Testing Instructions for Reviewers

Run management commands `./manage.py create_group_mapping`. Once you see the success message in the console
login to admin panel and check *Ad groups*, *Group* and *AD group mappings* for the correct list.
