### PR TITLE
Send permit end email on automatic permit ending

### DIFF
--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -13,9 +13,13 @@ db_logger = logging.getLogger("db")
 
 
 def automatic_expiration_of_permits():
-    ParkingPermit.objects.filter(
+    ending_permits = ParkingPermit.objects.filter(
         end_time__lt=tz.localdate(tz.now()), status=ParkingPermitStatus.VALID
-    ).update(status=ParkingPermitStatus.CLOSED)
+    )
+    for permit in ending_permits:
+        permit.status = ParkingPermitStatus.CLOSED
+        permit.save()
+        send_permit_email(PermitEmailType.ENDED, permit)
 
 
 def automatic_expiration_remind_notification_of_permits():

--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -13,6 +13,7 @@ db_logger = logging.getLogger("db")
 
 
 def automatic_expiration_of_permits():
+    logger.info("Automatically ending permits started...")
     ending_permits = ParkingPermit.objects.filter(
         end_time__lt=tz.localdate(tz.now()), status=ParkingPermitStatus.VALID
     )
@@ -20,6 +21,7 @@ def automatic_expiration_of_permits():
         permit.status = ParkingPermitStatus.CLOSED
         permit.save()
         send_permit_email(PermitEmailType.ENDED, permit)
+    logger.info("Automatically ending permits completed.")
 
 
 def automatic_expiration_remind_notification_of_permits():


### PR DESCRIPTION
## Description

Currently we do not explicitly sent permit ended email when permit is ended through a cronjob that handles automatic permit closing.

This PR adds email sending as a part of this cronjob functionality.

Refs: [PV-455](https://helsinkisolutionoffice.atlassian.net/browse/PV-455)

## How Has This Been Tested?

Manually, by running `./manage.py close_expired_permit`

