### PR TITLE
Vehicle low emission discount for 3rd party parking providers

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-12 14:48+0300\n"
+"POT-Creation-Date: 2022-10-18 09:14+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -643,6 +643,12 @@ msgstr "Tilapäinen ajoneuvo liitetty tunnukseen"
 msgid "Your parking permit will expire soon"
 msgstr "Pysäköintitunnuksesi voimassaoloaika päättyy pian"
 
+msgid "The vehicle is entitled to a discount"
+msgstr "Ajoneuvo oikeutettu alennukseen"
+
+msgid "Vehicle discount right expired"
+msgstr "Ajoneuvon alennusoikeus päättynyt"
+
 msgid "Your refund has been registered"
 msgstr "Palautus otettu käsittelyyn"
 
@@ -765,3 +771,23 @@ msgstr "Pysäköintitunnukseen on päivitetty tilapäisen ajoneuvon tiedot."
 
 msgid "Original vehicle has been restored to your permit."
 msgstr "Pysäköintitunnukseen on päivitetty alkuperäisen ajoneuvon tiedot."
+
+#, python-format
+msgid ""
+"The attached vehicle is entitled to a 50%% discount in street parking when "
+"paying with parking applications."
+msgstr ""
+"Oheinen ajoneuvo on oikeutettu 50%% alennukseen kadunvarsipysäköinnissä "
+"pysäköintisovelluksilla maksettaessa."
+
+msgid "Discount: Low-emission vehicle"
+msgstr "Alennus: Vähäpäästöinen ajoneuvo"
+
+msgid "Discount valid from"
+msgstr "Alennusoikeus voimassa alkaen"
+
+msgid "The right to a discount has been removed from the vehicle."
+msgstr "Ajoneuvolta on poistettu oikeus alennukseen."
+
+msgid "Discount right ends"
+msgstr "Alennusoikeus päättyy"

--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -21,6 +21,10 @@ def automatic_expiration_of_permits():
         permit.status = ParkingPermitStatus.CLOSED
         permit.save()
         send_permit_email(PermitEmailType.ENDED, permit)
+        if permit.consent_low_emission_accepted and permit.vehicle.is_low_emission:
+            send_permit_email(
+                PermitEmailType.VEHICLE_LOW_EMISSION_DISCOUNT_DEACTIVATED, permit
+            )
     logger.info("Automatically ending permits completed.")
 
 

--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -324,6 +324,14 @@ class CustomerPermit:
                 send_permit_email(
                     PermitEmailType.ENDED, ParkingPermit.objects.get(id=permit.id)
                 )
+                if (
+                    permit.consent_low_emission_accepted
+                    and permit.vehicle.is_low_emission
+                ):
+                    send_vehicle_low_emission_discount_email(
+                        PermitEmailType.VEHICLE_LOW_EMISSION_DISCOUNT_DEACTIVATED,
+                        permit,
+                    )
         # Delete all the draft permit while ending the customer valid permits
         draft_permits = self.customer_permit_query.filter(status=DRAFT)
         OrderItem.objects.filter(permit__in=draft_permits).delete()

--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -39,6 +39,7 @@ from .services.mail import (
     RefundEmailType,
     send_permit_email,
     send_refund_email,
+    send_vehicle_low_emission_discount_email,
 )
 from .utils import diff_months_floor, get_end_time
 
@@ -218,7 +219,7 @@ class CustomerPermit:
                 "consent_low_emission_accepted", False
             )
             permit.vehicle.save(update_fields=["consent_low_emission_accepted"])
-            return permit
+            return [permit]
 
         if "primary_vehicle" in keys:
             return self._toggle_primary_permit()

--- a/parking_permits/templates/emails/vehicle_low_emission_discount_activated.html
+++ b/parking_permits/templates/emails/vehicle_low_emission_discount_activated.html
@@ -1,0 +1,15 @@
+{% extends "emails/base.html" %}
+{% load i18n %}
+
+{% block title %}{% translate "The vehicle is entitled to a discount" %}{% endblock %}
+
+{% block content %}
+    <p>
+        {% translate "The attached vehicle is entitled to a 50% discount in street parking when paying with parking applications." %}
+    </p>
+    <p>
+        {% translate "Vehicle" %}: {{ permit.vehicle }}<br>
+        {% translate "Discount: Low-emission vehicle" %} <br>
+        {% translate "Discount valid from" %}: {{ permit.start_time|date:"j.n.Y, H:i" }}
+    </p>
+{% endblock %}

--- a/parking_permits/templates/emails/vehicle_low_emission_discount_deactivated.html
+++ b/parking_permits/templates/emails/vehicle_low_emission_discount_deactivated.html
@@ -1,0 +1,14 @@
+{% extends "emails/base.html" %}
+{% load i18n %}
+
+{% block title %}{% translate "Vehicle discount right expired" %}{% endblock %}
+
+{% block content %}
+    <p>
+        {% translate "The right to a discount has been removed from the vehicle." %}
+    </p>
+    <p>
+        {% translate "Vehicle" %}: {{ permit.vehicle }}<br>
+        {% translate "Discount right ends" %}: {{ permit.end_time|date:"j.n.Y, H:i" }}
+    </p>
+{% endblock %}

--- a/parking_permits/tests/test_customer_permit.py
+++ b/parking_permits/tests/test_customer_permit.py
@@ -251,7 +251,7 @@ class UpdateCustomerPermitTestCase(TestCase):
         data = {"consent_low_emission_accepted": True}
         self.assertEqual(self.c_a_draft.consent_low_emission_accepted, False)
         res = CustomerPermit(self.cus_a.id).update(data, self.c_a_draft.id)
-        self.assertEqual(res.consent_low_emission_accepted, True)
+        self.assertEqual(res[0].consent_low_emission_accepted, True)
 
     def test_can_not_update_consent_low_emission_accepted_for_closed(
         self,

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -200,6 +200,13 @@ class OrderView(APIView):
                 permit.status = ParkingPermitStatus.VALID
                 permit.save()
                 send_permit_email(PermitEmailType.CREATED, permit)
+                if (
+                    permit.consent_low_emission_accepted
+                    and permit.vehicle.is_low_emission
+                ):
+                    send_permit_email(
+                        PermitEmailType.VEHICLE_LOW_EMISSION_DISCOUNT_ACTIVATED, permit
+                    )
                 if not settings.DEBUG:
                     try:
                         permit.update_parkkihubi_permit()

--- a/project/settings.py
+++ b/project/settings.py
@@ -54,6 +54,7 @@ env = environ.Env(
     FIELD_ENCRYPTION_KEYS=(str, ""),
     SENTRY_DSN=(str, ""),
     SENTRY_ENVIRONMENT=(str, ""),
+    THIRD_PARTY_PARKING_PROVIDER_EMAILS=(list, []),
 )
 
 if path.exists(".env"):
@@ -265,6 +266,7 @@ EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")
 EMAIL_PORT = env.int("EMAIL_PORT")
 EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT")
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL")
+THIRD_PARTY_PARKING_PROVIDER_EMAILS = env("THIRD_PARTY_PARKING_PROVIDER_EMAILS")
 
 sentry_sdk.init(
     dsn=env.str("SENTRY_DSN"),


### PR DESCRIPTION
## Description

Send an email regarding accepted low-emission discount to all 3rd part mobile parking providers when permit vehicle changes, it is considered a low-emission vehicle and user has accepted consent for it.
Applicable in both applications: Parking Permits Webshop and Parking Permits Admin UI.

## Context

We need to send email regarding accepted low-emission discount to all 3rd part mobile parking providers.

This email needs to be sent per permit / vehicle only when user has accepted low-emission data usage checkbox during permit buying process. Email needs to be sent after valid payment process. Another message needs to be sent when the permit ends, to remove low-emission discount for this vehicle in the future.

Refs: [PV-367](https://helsinkisolutionoffice.atlassian.net/browse/PV-367)

## How Has This Been Tested?

Locally, by configuring env-variable: `THIRD_PARTY_PARKING_PROVIDER_EMAILS` to point to accessible email.

## Manual Testing Instructions for Reviewers

Configure `THIRD_PARTY_PARKING_PROVIDER_EMAILS` to point to your own email. Then try the following:
- Buy permit in webshop --> discount activated for the new vehicle
- Change vehicle in webshop --> discount deactivated for the old vehicle, discount activated for the new vehicle
- End permit in Webshop --> discount deactivated for the vehicle
- Create permit in Admin UI --> discount activated for the new vehicle
- Update permit in Admin UI (vehicle changes) --> discount deactivated for the old vehicle, discount activated for the new vehicle
- Update permit in Admin UI (vehicle does not change) --> no emails
- End permit in Admin UI --> discount deactivated for the vehicle
