### PR TITLE
PV-368: Send announcement emails

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -58,6 +58,7 @@ from .services.dvv import get_person_info
 from .services.mail import (
     PermitEmailType,
     RefundEmailType,
+    send_announcement_email,
     send_permit_email,
     send_refund_email,
     send_vehicle_low_emission_discount_email,
@@ -780,6 +781,11 @@ def resolve_announcement(obj, info, announcement_id):
         raise ObjectNotFound("Announcement not found")
 
 
+def post_create_announcement(announcement: Announcement):
+    customers = Customer.objects.filter(zone__in=announcement.parking_zones)
+    send_announcement_email(customers, announcement)
+
+
 @mutation.field("createAnnouncement")
 @is_super_admin
 @convert_kwargs_to_snake_case
@@ -799,5 +805,7 @@ def resolve_create_announcement(obj, info, announcement):
         new_announcement._parking_zones.set(
             ParkingZone.objects.filter(name__in=announcement["parking_zones"])
         )
+
+    post_create_announcement(new_announcement)
 
     return {"success": True}

--- a/parking_permits/services/mail.py
+++ b/parking_permits/services/mail.py
@@ -117,3 +117,27 @@ def send_refund_email(action, customer, refund):
             recipient_list,
             html_message=html_message,
         )
+
+
+def send_announcement_email(customers, announcement):
+    subject = f"{announcement.subject_fi} | {announcement.subject_sv} | {announcement.subject_en}"
+    template = "emails/announcement.html"
+
+    # Generate the messages
+    messages = []
+    for customer in customers:
+        with translation.override(customer.language):
+            html_message = render_to_string(
+                template, context={"announcement": announcement}
+            )
+        plain_message = strip_tags(html_message)
+        message = mail.EmailMultiAlternatives(
+            subject, plain_message, to=[customer.email]
+        )
+        message.attach_alternative(html_message, "text/html")
+        messages.append(message)
+
+    # Send the messages
+    if messages:
+        with mail.get_connection() as connection:
+            connection.send_messages(messages)

--- a/parking_permits/templates/emails/announcement.html
+++ b/parking_permits/templates/emails/announcement.html
@@ -1,0 +1,11 @@
+{% extends "emails/base_multilingual.html" %}
+{% load i18n %}
+
+{% block title_fi %}{{ announcement.subject_fi }}{% endblock %}
+{% block content_fi %}{{ announcement.content_fi }}{% endblock %}
+
+{% block title_sv %}{{ announcement.subject_sv }}{% endblock %}
+{% block content_sv %}{{ announcement.content_sv }}{% endblock %}
+
+{% block title_en %}{{ announcement.subject_en }}{% endblock %}
+{% block content_en %}{{ announcement.content_en }}{% endblock %}

--- a/parking_permits/templates/emails/base_multilingual.html
+++ b/parking_permits/templates/emails/base_multilingual.html
@@ -1,0 +1,177 @@
+{% load i18n %}
+<!DOCTYPE html>
+<html lang="fi">
+
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title></title>
+    <style>
+        body {
+            width: 100%;
+        }
+
+        .header {
+            padding: 0 16px;
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            border-radius: 0;
+            height: 60px;
+        }
+
+        .header-logo {
+            max-height: 60px;
+            width: auto;
+            height: auto;
+            margin-right: 10px;
+        }
+
+        .content {
+            padding: 0 16px;
+        }
+
+        .title {
+            height: 29px;
+            color: rgb(26, 26, 26);
+            font-size: 24px;
+            font-weight: bold;
+            line-height: 29px;
+        }
+
+        .message-title {
+            margin-top: 16px;
+            color: rgb(26, 26, 26);
+            font-size: 36px;
+            font-weight: bold;
+            height: 43px;
+            line-height: 43px;
+            white-space: nowrap;
+            overflow: hidden;
+        }
+
+        .message-title-divider {
+            margin-top: 12px;
+            background: rgb(0, 0, 191);
+            border-radius: 0;
+            height: 3px;
+        }
+
+        .noreply-description {
+            margin-top: 38px;
+            color: rgb(102, 102, 102);
+            font-size: 14px;
+            font-weight: normal;
+            height: 52px;
+            line-height: 26px;
+        }
+
+        .message-body {
+            color: rgb(26, 26, 26);
+            font-size: 16px;
+            font-weight: normal;
+            line-height: 24px;
+            margin-top: 14px;
+            margin-bottom: 88px;
+        }
+
+        .footer {
+            padding: 16px;
+            background-color: #f2f2f2;
+        }
+
+        .footer-header {
+            height: 64px;
+        }
+
+        .footer-title {
+            height: 24px;
+            color: rgb(26, 26, 26);
+            font-size: 20px;
+            font-weight: bold;
+            line-height: 64px;
+            margin-top: 18px;
+            margin-bottom: 24px;
+        }
+
+        .footer-links {
+            padding: 16px 0;
+            border-top: 1px solid #1a1a1a;
+            border-bottom: 1px solid #1a1a1a;
+        }
+
+        .link-item {
+            height: 24px;
+            color: rgb(26, 26, 26);
+            font-size: 16px;
+            font-weight: normal;
+            line-height: 24px;
+            margin-right: 16px;
+            text-decoration: none;
+        }
+
+        .footer-logo {
+            max-height: 42px;
+            margin: 16px 0;
+        }
+
+        .copyright {
+            margin: 16px 0;
+        }
+    </style>
+</head>
+
+<body>
+<div class="header">
+    <img class="header-logo" alt="Helsinki City"
+         src="data:image/svg+xml, %3Csvg viewBox='0 0 78 36' role='img' xmlns='http://www.w3.org/2000/svg' class='logo' aria-hidden='true'%3E%3Cpath d='M75.753 2.251v20.7c0 3.95-3.275 7.178-7.31 7.178h-22.26c-2.674 0-5.205.96-7.183 2.739a10.749 10.749 0 00-7.183-2.74H9.509c-4.003 0-7.247-3.21-7.247-7.177V2.25h73.491zM40.187 34.835a8.47 8.47 0 016.012-2.471h22.245c5.268 0 9.556-4.219 9.556-9.413V0H0v22.935c0 5.194 4.256 9.413 9.509 9.413h22.308c2.263 0 4.398.882 6.012 2.471L39.016 36l1.17-1.165z' fill='currentColor'%3E%3C/path%3E%3Cpath d='M67.522 11.676c0 .681-.556 1.177-1.255 1.177-.7 0-1.255-.496-1.255-1.177 0-.682.556-1.178 1.255-1.178.7-.03 1.255.465 1.255 1.178zm-2.352 9.622h2.178v-7.546H65.17v7.546zm-3.909-4.556l2.845 4.556h-2.368l-1.907-3.022-1.033 1.271v1.75h-2.161V10.453h2.16v5.004c0 .93-.11 1.86-.11 1.86h.047s.509-.821.938-1.41l1.653-2.154h2.542l-2.606 2.99zm-6.817-.278c0-1.875-.938-2.898-2.432-2.898-1.271 0-1.939.728-2.32 1.426h-.048l.112-1.24h-2.162v7.546h2.162V16.82c0-.868.524-1.472 1.335-1.472.81 0 1.16.527 1.16 1.534v4.416h2.177l.016-4.834zm-8.931-4.788c0 .681-.557 1.177-1.256 1.177-.7 0-1.255-.496-1.255-1.177 0-.682.556-1.178 1.255-1.178.715-.03 1.256.465 1.256 1.178zm-2.352 9.622h2.177v-7.546H43.16v7.546zm-3.75-2.107c0-.605-.859-.729-1.86-1.008-1.16-.294-2.622-.867-2.622-2.308 0-1.426 1.398-2.324 3.051-2.324 1.541 0 2.956.712 3.544 1.72l-1.86 1.022c-.19-.666-.762-1.193-1.62-1.193-.557 0-1.018.232-1.018.682 0 .573 1.018.635 2.162.991 1.208.372 2.32.915 2.32 2.294 0 1.518-1.446 2.417-3.115 2.417-1.811 0-3.242-.744-3.877-1.952l1.89-1.039c.24.822.922 1.441 1.955 1.441.62 0 1.05-.248 1.05-.743zm-6.882-8.677h-2.177v8.692c0 .775.175 1.348.509 1.705.35.356.89.526 1.636.526.255 0 .525-.03.78-.077.27-.062.476-.14.65-.233l.191-1.425a2.07 2.07 0 01-.46.124c-.128.03-.287.03-.461.03-.286 0-.414-.077-.509-.216-.111-.14-.159-.387-.159-.744v-8.382zm-7.246 4.57c-.795 0-1.446.558-1.621 1.581h3.05c.017-.899-.587-1.58-1.43-1.58zm3.353 3.007H23.63c.095 1.224.794 1.828 1.7 1.828.81 0 1.367-.527 1.494-1.24l1.828 1.007c-.54.961-1.7 1.798-3.322 1.798-2.16 0-3.75-1.472-3.75-3.951 0-2.464 1.62-3.951 3.703-3.951 2.081 0 3.464 1.44 3.464 3.486-.016.604-.111 1.023-.111 1.023zm-11.077 3.207h2.257V10.916h-2.257v4.107h-4.243v-4.091H11.06v10.366h2.256v-4.292h4.243v4.292z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E"/>
+    <span class="title">{% translate "Parking permits" %}</span>
+</div>
+<div class="content">
+    {% language 'fi' %}
+    <div class="message-title">{% block title_fi %}{% endblock %}</div>
+    <div class="message-title-divider"></div>
+    <div class="noreply-description">
+        {% translate "This message has been sent automatically from the system. Please do not reply to this message as replies will not be processed." %}
+    </div>
+    <div class="message-body">
+        {% block content_fi %}{% endblock %}
+    </div>
+    {% endlanguage %}
+
+    {% language 'sv' %}
+    <div class="message-title">{% block title_sv %}{% endblock %}</div>
+    <div class="message-title-divider"></div>
+    <div class="noreply-description">
+        {% translate "This message has been sent automatically from the system. Please do not reply to this message as replies will not be processed." %}
+    </div>
+    <div class="message-body">
+        {% block content_sv %}{% endblock %}
+    </div>
+    {% endlanguage %}
+
+    {% language 'en' %}
+    <div class="message-title">{% block title_en %}{% endblock %}</div>
+    <div class="message-title-divider"></div>
+    <div class="noreply-description">
+        {% translate "This message has been sent automatically from the system. Please do not reply to this message as replies will not be processed." %}
+    </div>
+    <div class="message-body">
+        {% block content_en %}{% endblock %}
+    </div>
+    {% endlanguage %}
+</div>
+<div class="footer">
+    <div class="footer-header"><span class="footer-title">{% translate "Parking permits" %}</span></div>
+    <div class="footer-links">
+        <a class="link-item" href="#">{% translate "Parking permit terms of usage" %}</a>
+        <a class="link-item" href="#">{% translate "Support" %}</a>
+        <a class="link-item" href="#">{% translate "Feedback" %}</a>
+        <a class="link-item" href="#">{% translate "Customer service contact info" %}</a>
+    </div>
+    <img class="footer-logo" alt="Helsinki City"
+         src="data:image/svg+xml, %3Csvg viewBox='0 0 78 36' role='img' xmlns='http://www.w3.org/2000/svg' class='logo' aria-hidden='true'%3E%3Cpath d='M75.753 2.251v20.7c0 3.95-3.275 7.178-7.31 7.178h-22.26c-2.674 0-5.205.96-7.183 2.739a10.749 10.749 0 00-7.183-2.74H9.509c-4.003 0-7.247-3.21-7.247-7.177V2.25h73.491zM40.187 34.835a8.47 8.47 0 016.012-2.471h22.245c5.268 0 9.556-4.219 9.556-9.413V0H0v22.935c0 5.194 4.256 9.413 9.509 9.413h22.308c2.263 0 4.398.882 6.012 2.471L39.016 36l1.17-1.165z' fill='currentColor'%3E%3C/path%3E%3Cpath d='M67.522 11.676c0 .681-.556 1.177-1.255 1.177-.7 0-1.255-.496-1.255-1.177 0-.682.556-1.178 1.255-1.178.7-.03 1.255.465 1.255 1.178zm-2.352 9.622h2.178v-7.546H65.17v7.546zm-3.909-4.556l2.845 4.556h-2.368l-1.907-3.022-1.033 1.271v1.75h-2.161V10.453h2.16v5.004c0 .93-.11 1.86-.11 1.86h.047s.509-.821.938-1.41l1.653-2.154h2.542l-2.606 2.99zm-6.817-.278c0-1.875-.938-2.898-2.432-2.898-1.271 0-1.939.728-2.32 1.426h-.048l.112-1.24h-2.162v7.546h2.162V16.82c0-.868.524-1.472 1.335-1.472.81 0 1.16.527 1.16 1.534v4.416h2.177l.016-4.834zm-8.931-4.788c0 .681-.557 1.177-1.256 1.177-.7 0-1.255-.496-1.255-1.177 0-.682.556-1.178 1.255-1.178.715-.03 1.256.465 1.256 1.178zm-2.352 9.622h2.177v-7.546H43.16v7.546zm-3.75-2.107c0-.605-.859-.729-1.86-1.008-1.16-.294-2.622-.867-2.622-2.308 0-1.426 1.398-2.324 3.051-2.324 1.541 0 2.956.712 3.544 1.72l-1.86 1.022c-.19-.666-.762-1.193-1.62-1.193-.557 0-1.018.232-1.018.682 0 .573 1.018.635 2.162.991 1.208.372 2.32.915 2.32 2.294 0 1.518-1.446 2.417-3.115 2.417-1.811 0-3.242-.744-3.877-1.952l1.89-1.039c.24.822.922 1.441 1.955 1.441.62 0 1.05-.248 1.05-.743zm-6.882-8.677h-2.177v8.692c0 .775.175 1.348.509 1.705.35.356.89.526 1.636.526.255 0 .525-.03.78-.077.27-.062.476-.14.65-.233l.191-1.425a2.07 2.07 0 01-.46.124c-.128.03-.287.03-.461.03-.286 0-.414-.077-.509-.216-.111-.14-.159-.387-.159-.744v-8.382zm-7.246 4.57c-.795 0-1.446.558-1.621 1.581h3.05c.017-.899-.587-1.58-1.43-1.58zm3.353 3.007H23.63c.095 1.224.794 1.828 1.7 1.828.81 0 1.367-.527 1.494-1.24l1.828 1.007c-.54.961-1.7 1.798-3.322 1.798-2.16 0-3.75-1.472-3.75-3.951 0-2.464 1.62-3.951 3.703-3.951 2.081 0 3.464 1.44 3.464 3.486-.016.604-.111 1.023-.111 1.023zm-11.077 3.207h2.257V10.916h-2.257v4.107h-4.243v-4.091H11.06v10.366h2.256v-4.292h4.243v4.292z' fill='currentColor'%3E%3C/path%3E%3C/svg%3E"/>
+    <div class="copyright">© {% translate "City of Helsinki" %} {% now "Y" %}</div>
+</div>
+</body>
+</html>

--- a/parking_permits/tests/factories/announcement.py
+++ b/parking_permits/tests/factories/announcement.py
@@ -1,0 +1,8 @@
+import factory
+
+from parking_permits.models import Announcement
+
+
+class AnnouncementFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Announcement

--- a/parking_permits/tests/test_announcement.py
+++ b/parking_permits/tests/test_announcement.py
@@ -1,0 +1,182 @@
+import importlib
+from unittest.mock import MagicMock, patch
+
+from django.core import mail
+from django.test import TestCase
+
+from parking_permits import admin_resolvers
+from parking_permits.models import Announcement
+from parking_permits.services.mail import send_announcement_email
+from parking_permits.tests.factories import ParkingZoneFactory
+from parking_permits.tests.factories.announcement import AnnouncementFactory
+from parking_permits.tests.factories.customer import CustomerFactory
+from users.tests.factories.user import UserFactory
+
+
+@patch("parking_permits.admin_resolvers.post_create_announcement")
+class CreateAnnouncementResolverTest(TestCase):
+    def setUp(self):
+        # Patch the authentication decorators and reload the module, so we can
+        # directly test the resolver without authentication shenanigans.
+        def kill_patches():
+            patch.stopall()
+            importlib.reload(admin_resolvers)
+
+        self.addCleanup(kill_patches)
+
+        patch("parking_permits.decorators.is_authenticated", lambda x: x).start()
+        patch("parking_permits.decorators.is_super_admin", lambda x: x).start()
+        importlib.reload(admin_resolvers)
+
+        # Mock the info object passed for the resolver.
+        user = UserFactory()
+        request = MagicMock(user=user)
+        self.info = MagicMock(context={"request": request})
+
+        self.announcement = dict(
+            content_fi="Content FI",
+            content_en="Content EN",
+            content_sv="Content SV",
+            subject_en="Subject EN",
+            subject_fi="Subject FI",
+            subject_sv="Subject SV",
+            parking_zones=[],
+        )
+
+    def test_happy_day_scenario(self, mock_post_create_announcement):
+        message = admin_resolvers.resolve_create_announcement(
+            None, self.info, self.announcement
+        )
+
+        self.assertDictEqual(message, {"success": True})
+        mock_post_create_announcement.assert_called_once()
+        self.assertEqual(len(Announcement.objects.all()), 1)
+
+    def test_should_set_correct_parking_zones(self, mock_post_create_announcement):
+        zone_a = ParkingZoneFactory(name="A")
+        zone_b = ParkingZoneFactory(name="B")
+        ParkingZoneFactory(name="C")
+
+        self.announcement["parking_zones"] = ["A", "B", "some utter nonsense"]
+
+        admin_resolvers.resolve_create_announcement(None, self.info, self.announcement)
+
+        self.assertEqual(len(Announcement.objects.all()), 1)
+
+        announcement_from_db = Announcement.objects.first()
+        announcement_zones = announcement_from_db.parking_zones.order_by("name")
+
+        self.assertEqual(len(announcement_zones), 2)
+        self.assertEqual(announcement_zones[0], zone_a)
+        self.assertEqual(announcement_zones[1], zone_b)
+
+
+@patch("parking_permits.admin_resolvers.send_announcement_email")
+class PostCreateAnnouncementTest(TestCase):
+    def setUp(self):
+        self.announcement = AnnouncementFactory()
+
+    def test_should_have_no_customers_for_an_empty_parking_zone(
+        self, mock_send_announcement_email: MagicMock
+    ):
+        empty_zone = ParkingZoneFactory(name="Empty")
+        self.announcement._parking_zones.set([empty_zone])
+        admin_resolvers.post_create_announcement(self.announcement)
+
+        mock_send_announcement_email.assert_called_once()
+        customers_arg = mock_send_announcement_email.call_args.args[0]
+        self.assertEqual(len(customers_arg), 0)
+
+    def test_should_get_correct_customers_from_single_parking_zone(
+        self, mock_send_announcement_email: MagicMock
+    ):
+        # Create zones A and B; A will be the target for our announcement.
+        zone_a = ParkingZoneFactory(name="A")
+        zone_b = ParkingZoneFactory(name="B")
+
+        # Create customers for the zones.
+        zone_a_customer = CustomerFactory(zone=zone_a)
+        CustomerFactory(zone=zone_b)
+
+        # Set the announcement for zone A.
+        self.announcement._parking_zones.set([zone_a])
+
+        admin_resolvers.post_create_announcement(self.announcement)
+
+        # Should have only one customer (from zone A).
+        mock_send_announcement_email.assert_called_once()
+        customers_arg = mock_send_announcement_email.call_args.args[0]
+        self.assertEqual(len(customers_arg), 1)
+        filtered_customer = customers_arg.first()
+        self.assertEqual(filtered_customer, zone_a_customer)
+
+    def test_should_get_correct_customers_from_multiple_parking_zones(
+        self, mock_send_announcement_email: MagicMock
+    ):
+        # Create zones A, B and C; A and B will be the targets for our announcement.
+        zone_a = ParkingZoneFactory(name="A")
+        zone_b = ParkingZoneFactory(name="B")
+        zone_c = ParkingZoneFactory(name="C")
+
+        # Create customers for the zones.
+        zone_a_customer = CustomerFactory(zone=zone_a)
+        zone_b_customer = CustomerFactory(zone=zone_b)
+        CustomerFactory(zone=zone_c)
+        expected_customers = [zone_a_customer, zone_b_customer]
+
+        # Set the announcement for zone A & B.
+        self.announcement._parking_zones.set([zone_a, zone_b])
+        admin_resolvers.post_create_announcement(self.announcement)
+
+        # Should have two customers (from zone A & B).
+        mock_send_announcement_email.assert_called_once()
+        customers_arg = mock_send_announcement_email.call_args.args[0]
+        self.assertEqual(len(customers_arg), 2)
+        for idx, customer in enumerate(customers_arg.order_by("zone__name")):
+            self.assertEqual(customer, expected_customers[idx])
+
+
+class SendAnnouncementMailTest(TestCase):
+    def setUp(self):
+        self.announcement = AnnouncementFactory()
+
+    def test_should_do_nothing_if_no_customers(self):
+        send_announcement_email([], self.announcement)
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_should_send_mail_for_a_single_customer(self):
+        customer = CustomerFactory(email="foo@bar.test")
+        send_announcement_email([customer], self.announcement)
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_should_send_mail_for_multiple_customers(self):
+        customers = [CustomerFactory(email=f"foo{i}@bar.test") for i in range(1, 11)]
+        send_announcement_email(customers, self.announcement)
+        self.assertEqual(len(mail.outbox), 10)
+
+    def test_mail_should_contain_all_translations(self):
+        contents_subjects = dict(
+            content_fi="Content FI",
+            content_en="Content EN",
+            content_sv="Content SV",
+            subject_en="Subject EN",
+            subject_fi="Subject FI",
+            subject_sv="Subject SV",
+        )
+        announcement = AnnouncementFactory(
+            content_fi="Content FI",
+            content_en="Content EN",
+            content_sv="Content SV",
+            subject_en="Subject EN",
+            subject_fi="Subject FI",
+            subject_sv="Subject SV",
+        )
+        send_announcement_email([CustomerFactory()], announcement)
+        sent_email = mail.outbox[0]
+        html_body, content_type = sent_email.alternatives[0]
+
+        self.assertEqual(content_type, "text/html")
+        self.assertEqual(sent_email.subject, "Subject FI | Subject SV | Subject EN")
+        for value in contents_subjects.values():
+            self.assertIn(value, sent_email.body)
+            self.assertIn(value, html_body)


### PR DESCRIPTION
## Description

Adds the initial implementation of sending announcement emails upon creating announcements. Very rudimentary, and should be revisited later on (e.g. make it a background task).

## Context

The admin needs to be able to send announcement emails to the customers of specified parking zones. Currently, there's a back-end implementation for the announcements, but it does nothing on its own. This PR makes it actually send emails.

[PV-368](https://helsinkisolutionoffice.atlassian.net/browse/PV-368)

## How Has This Been Tested?

Wrote some basic unit tests to cover the most obvious cases (translations & correct audience). In addition, did some manual testing via the admin UI locally. What I didn't test is sending the actual email in my inbox in its fully rendered form.

## Manual Testing Instructions for Reviewers

Either do a manual GQL query to the `createAnnouncement` endpoint or use the admin UI to create a new announcement. If running in a local development environment, the email should show up in the log output. Alternatively, you can set up a file-based email back-end in `settings.py`:

```
EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
EMAIL_FILE_PATH = "./tmp/app-messages"  # change this to a proper location
```

Currently, the admin UI's a bit broken due to permission changes (at least for me), so you might have to poke around the code a bit to get around the permissions (e.g. change the `@is_super_admin` decorators to something more lenient, like `@is_authenticated`, or whatever works for you).
