### PR TITLE
PV-421/PV-444: Add customer list, retrieve customer by ID, retrieve more customer data, fix GDPR API view

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -43,6 +43,7 @@ from .exceptions import (
 from .forms import (
     AddressSearchForm,
     AnnouncementSearchForm,
+    CustomerSearchForm,
     LowEmissionCriteriaSearchForm,
     OrderSearchForm,
     PermitSearchForm,
@@ -135,6 +136,23 @@ def resolve_customer(obj, info, national_id_number):
         if not customer:
             raise ObjectNotFound(_("Person not found"))
     return customer
+
+
+@query.field("customers")
+@is_super_admin
+@convert_kwargs_to_snake_case
+def resolve_customers(obj, info, page_input, order_by=None, search_params=None):
+    form_data = {**page_input}
+    if order_by:
+        form_data.update(order_by)
+    if search_params:
+        form_data.update(search_params)
+
+    form = CustomerSearchForm(form_data)
+    if not form.is_valid():
+        logger.error(f"Customer search error: {form.errors}")
+        raise SearchError("Customer search error")
+    return form.get_paged_queryset()
 
 
 @query.field("vehicle")

--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -127,12 +127,15 @@ def resolve_zone_by_location(obj, info, location):
 @query.field("customer")
 @is_super_admin
 @convert_kwargs_to_snake_case
-def resolve_customer(obj, info, national_id_number):
+def resolve_customer(obj, info, **data):
+    query_params = data.get("query")
     try:
-        customer = Customer.objects.get(national_id_number=national_id_number)
+        customer = Customer.objects.get(**query_params)
     except Customer.DoesNotExist:
-        logger.info("Customer does not exist, searching from DVV...")
-        customer = get_person_info(national_id_number)
+        customer = None
+        if query_params.get("national_id_number"):
+            logger.info("Customer does not exist, searching from DVV...")
+            customer = get_person_info(query_params.get("national_id_number"))
         if not customer:
             raise ObjectNotFound(_("Person not found"))
     return customer

--- a/parking_permits/models/customer.py
+++ b/parking_permits/models/customer.py
@@ -86,8 +86,8 @@ class Customer(SerializableMixin, TimestampedModelMixin):
         {"name": "national_id_number"},
         {"name": "email"},
         {"name": "phone_number"},
-        {"name": "primary_address", "accessor": lambda a: a.serialize()},
-        {"name": "other_address", "accessor": lambda a: a.serialize()},
+        {"name": "primary_address", "accessor": lambda a: a.serialize() if a else None},
+        {"name": "other_address", "accessor": lambda a: a.serialize() if a else None},
         {"name": "orders"},
         {"name": "permits"},
     )

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -40,6 +40,7 @@ type CustomerActivePermit {
 
 type CustomerNode {
   id: ID
+  sourceId: String
   firstName: String
   lastName: String
   nationalIdNumber: String

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -169,6 +169,11 @@ type PagedAnnouncements {
   pageInfo: PageInfo
 }
 
+type PagedCustomers {
+  objects: [CustomerNode]
+  pageInfo: PageInfo
+}
+
 enum OrderDirection {
   ASC,
   DESC
@@ -275,6 +280,11 @@ input PermitSearchParamsInput {
   status: String!
 }
 
+input CustomerSearchParamsInput {
+  name: String!
+  nationalIdNumber: String!
+}
+
 input RefundSearchParamsInput {
   q: String!
   startDate: String!
@@ -291,6 +301,11 @@ type Query {
    ): PagedPermits!
   permitDetail(permitId: ID!): PermitDetailNode!
   zones: [ZoneNode]
+  customers(
+    pageInput: PageInput!
+    orderBy: OrderByInput
+    searchParams: CustomerSearchParamsInput
+  ): PagedCustomers!
   customer(nationalIdNumber: String!): CustomerNode!
   vehicle(regNumber: String!, nationalIdNumber: String!): VehicleNode!
   products(

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -39,6 +39,7 @@ type CustomerActivePermit {
 }
 
 type CustomerNode {
+  id: ID
   firstName: String
   lastName: String
   nationalIdNumber: String
@@ -50,6 +51,7 @@ type CustomerNode {
   addressSecurityBan: Boolean
   driverLicenseChecked: Boolean
   activePermits: [CustomerActivePermit]
+  language: String
 }
 
 type VehicleNode {
@@ -293,6 +295,11 @@ input RefundSearchParamsInput {
   paymentTypes: String!
 }
 
+input CustomerRetrieveInput {
+  id: ID
+  nationalIdNumber: String
+}
+
 type Query {
   permits(
     pageInput: PageInput!
@@ -306,7 +313,7 @@ type Query {
     orderBy: OrderByInput
     searchParams: CustomerSearchParamsInput
   ): PagedCustomers!
-  customer(nationalIdNumber: String!): CustomerNode!
+  customer(query: CustomerRetrieveInput!): CustomerNode!
   vehicle(regNumber: String!, nationalIdNumber: String!): VehicleNode!
   products(
     pageInput: PageInput!

--- a/parking_permits/tests/test_forms.py
+++ b/parking_permits/tests/test_forms.py
@@ -1,10 +1,12 @@
+import pytest
 from django.test import TestCase
 from django.utils import timezone
 
-from parking_permits.forms import OrderSearchForm, PdfExportForm
+from parking_permits.forms import CustomerSearchForm, OrderSearchForm, PdfExportForm
 from parking_permits.models.parking_permit import ContractType, ParkingPermitType
 from parking_permits.tests.factories import ParkingZoneFactory
 from parking_permits.tests.factories.address import AddressFactory
+from parking_permits.tests.factories.customer import CustomerFactory
 from parking_permits.tests.factories.order import OrderFactory
 from parking_permits.tests.factories.parking_permit import ParkingPermitFactory
 
@@ -308,3 +310,24 @@ class OrderSearchFormDateRangeTestCase(TestCase):
                 },
             ],
         )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("doe", id="last-name"),
+        pytest.param("john", id="first-name"),
+        pytest.param("john doe", id="full-name"),
+        pytest.param("doe john", id="full-name-reverse"),
+    ],
+)
+def test_customer_search_form_search_by_name(name):
+    CustomerFactory(first_name="Foo", last_name="Bar")
+    customer = CustomerFactory(first_name="John", last_name="Doe")
+    form = CustomerSearchForm({"name": name})
+
+    assert form.is_valid()
+    qs = form.get_queryset()
+    assert len(qs) == 1
+    assert qs.first() == customer


### PR DESCRIPTION
## Description

Adds the back-end functionality required for both [PV-421](https://helsinkisolutionoffice.atlassian.net/browse/PV-421) and [PV-444](https://helsinkisolutionoffice.atlassian.net/browse/PV-444):

- Add customer list
- Add support for retrieving a customer by ID
  - Now you can retrieve a customer with the national ID number or/and the customer ID
- Add more fields to customer node
- Fix GDPR API view, i.e. fix Customer model serialization (both addresses are nullable -> null addresses were causing a crash)

## Context

This is required for the customer list and customer detail view in the admin UI. The customer model fix is required so the data can be downloaded.

[PV-421](https://helsinkisolutionoffice.atlassian.net/browse/PV-421)
[PV-444](https://helsinkisolutionoffice.atlassian.net/browse/PV-444)

## How Has This Been Tested?

Mostly manually, via the admin UI. Some unit tests are included, namely the customer search by name.

## Manual Testing Instructions for Reviewers

Not much to test, other than the resolvers. Might make sense to test this with the admin UI changes.
