### PR TITLE
Show only vehicle registration number third party emails

### DIFF
--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -6,7 +6,11 @@ from django.utils import timezone as tz
 from parking_permits.exceptions import ParkkihubiPermitError
 from parking_permits.models import Customer, ParkingPermit
 from parking_permits.models.parking_permit import ParkingPermitStatus
-from parking_permits.services.mail import PermitEmailType, send_permit_email
+from parking_permits.services.mail import (
+    PermitEmailType,
+    send_permit_email,
+    send_vehicle_low_emission_discount_email,
+)
 
 logger = logging.getLogger("django")
 db_logger = logging.getLogger("db")
@@ -22,7 +26,7 @@ def automatic_expiration_of_permits():
         permit.save()
         send_permit_email(PermitEmailType.ENDED, permit)
         if permit.consent_low_emission_accepted and permit.vehicle.is_low_emission:
-            send_permit_email(
+            send_vehicle_low_emission_discount_email(
                 PermitEmailType.VEHICLE_LOW_EMISSION_DISCOUNT_DEACTIVATED, permit
             )
     logger.info("Automatically ending permits completed.")

--- a/parking_permits/templates/emails/vehicle_low_emission_discount_activated.html
+++ b/parking_permits/templates/emails/vehicle_low_emission_discount_activated.html
@@ -8,7 +8,7 @@
         {% translate "The attached vehicle is entitled to a 50% discount in street parking when paying with parking applications." %}
     </p>
     <p>
-        {% translate "Vehicle" %}: {{ permit.vehicle }}<br>
+        {% translate "Vehicle" %}: {{ permit.vehicle.registration_number }}<br>
         {% translate "Discount: Low-emission vehicle" %} <br>
         {% translate "Discount valid from" %}: {{ permit.start_time|date:"j.n.Y, H:i" }}
     </p>

--- a/parking_permits/templates/emails/vehicle_low_emission_discount_deactivated.html
+++ b/parking_permits/templates/emails/vehicle_low_emission_discount_deactivated.html
@@ -8,7 +8,7 @@
         {% translate "The right to a discount has been removed from the vehicle." %}
     </p>
     <p>
-        {% translate "Vehicle" %}: {{ permit.vehicle }}<br>
+        {% translate "Vehicle" %}: {{ permit.vehicle.registration_number }}<br>
         {% translate "Discount right ends" %}: {{ permit.end_time|date:"j.n.Y, H:i" }}
     </p>
 {% endblock %}

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -41,7 +41,11 @@ from .serializers import (
     RightOfPurchaseResponseSerializer,
     TalpaPayloadSerializer,
 )
-from .services.mail import PermitEmailType, send_permit_email
+from .services.mail import (
+    PermitEmailType,
+    send_permit_email,
+    send_vehicle_low_emission_discount_email,
+)
 from .utils import get_meta_value, snake_to_camel_dict
 
 logger = logging.getLogger("db")
@@ -204,7 +208,7 @@ class OrderView(APIView):
                     permit.consent_low_emission_accepted
                     and permit.vehicle.is_low_emission
                 ):
-                    send_permit_email(
+                    send_vehicle_low_emission_discount_email(
                         PermitEmailType.VEHICLE_LOW_EMISSION_DISCOUNT_ACTIVATED, permit
                     )
                 if not settings.DEBUG:


### PR DESCRIPTION
## Description

It is not needed to show other vehicle informations than registration number in third party low-emission emails.
Therefore remove other vehicle informations from the email-template and leave only the vehicle registration number.

Also update to use correct functions for all low-emissions email sending cases.

[PV-457](https://helsinkisolutionoffice.atlassian.net/browse/PV-457)

## How Has This Been Tested?

Manually, using existing management commands and observing the output.

## Manual Testing Instructions for Reviewers

Test by preparing correct data and then running management commands that send third party low-emission emails.