### PR TITLE
Role base access control

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -30,6 +30,8 @@ from parking_permits.models import (
 )
 
 from .decorators import is_super_admin
+    is_inspectors,
+    is_preparators,
 from .exceptions import (
     CreatePermitError,
     ObjectNotFound,
@@ -75,10 +77,7 @@ PermitDetail = ObjectType("PermitDetailNode")
 schema_bindables = [query, mutation, PermitDetail, snake_case_fallback_resolvers]
 
 
-@query.field("permits")
-@is_super_admin
-@convert_kwargs_to_snake_case
-def resolve_permits(obj, info, page_input, order_by=None, search_params=None):
+def get_permits(page_input, order_by=None, search_params=None):
     form_data = {**page_input}
     if order_by:
         form_data.update(order_by)
@@ -90,6 +89,20 @@ def resolve_permits(obj, info, page_input, order_by=None, search_params=None):
         logger.error(f"Permit Search Error: {form.errors}")
         raise SearchError("Permit search error")
     return form.get_paged_queryset()
+
+
+@query.field("permits")
+@is_preparators
+@convert_kwargs_to_snake_case
+def resolve_permits(obj, info, page_input, order_by=None, search_params=None):
+    return get_permits(page_input, order_by, search_params)
+
+
+@query.field("limitedPermits")
+@is_inspectors
+@convert_kwargs_to_snake_case
+def resolve_limited_permits(obj, info, page_input, order_by=None, search_params=None):
+    return get_permits(page_input, order_by, search_params)
 
 
 @query.field("permitDetail")

--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -29,9 +29,14 @@ from parking_permits.models import (
     Vehicle,
 )
 
-from .decorators import is_super_admin
+from .decorators import (
+    is_customer_service,
     is_inspectors,
     is_preparators,
+    is_sanctions,
+    is_sanctions_and_returns,
+    is_super_admin,
+)
 from .exceptions import (
     CreatePermitError,
     ObjectNotFound,
@@ -106,7 +111,7 @@ def resolve_limited_permits(obj, info, page_input, order_by=None, search_params=
 
 
 @query.field("permitDetail")
-@is_super_admin
+@is_preparators
 @convert_kwargs_to_snake_case
 def resolve_permit_detail(obj, info, permit_id):
     return ParkingPermit.objects.get(id=permit_id)
@@ -252,7 +257,7 @@ def create_permit_address(customer_info):
 
 
 @mutation.field("createResidentPermit")
-@is_super_admin
+@is_preparators
 @convert_kwargs_to_snake_case
 @transaction.atomic
 def resolve_create_resident_permit(obj, info, permit):
@@ -570,7 +575,7 @@ def resolve_create_product(obj, info, product):
 
 
 @query.field("refunds")
-@is_super_admin
+@is_preparators
 @convert_kwargs_to_snake_case
 def resolve_refunds(obj, info, page_input, order_by=None, search_params=None):
     form_data = {**page_input}
@@ -587,7 +592,7 @@ def resolve_refunds(obj, info, page_input, order_by=None, search_params=None):
 
 
 @mutation.field("requestForApproval")
-@is_super_admin
+@is_sanctions
 @convert_kwargs_to_snake_case
 def resolve_request_for_approval(obj, info, ids):
     qs = Refund.objects.filter(id__in=ids, status=RefundStatus.OPEN)
@@ -596,7 +601,7 @@ def resolve_request_for_approval(obj, info, ids):
 
 
 @mutation.field("acceptRefunds")
-@is_super_admin
+@is_sanctions_and_returns
 @convert_kwargs_to_snake_case
 def resolve_accept_refunds(obj, info, ids):
     request = info.context["request"]
@@ -625,7 +630,7 @@ def resolve_refund(obj, info, refund_id):
 
 
 @mutation.field("updateRefund")
-@is_super_admin
+@is_customer_service
 @convert_kwargs_to_snake_case
 def resolve_update_refund(obj, info, refund_id, refund):
     request = info.context["request"]
@@ -642,7 +647,7 @@ def resolve_update_refund(obj, info, refund_id, refund):
 
 
 @query.field("orders")
-@is_super_admin
+@is_preparators
 @convert_kwargs_to_snake_case
 def resolve_orders(obj, info, page_input, order_by=None, search_params=None):
     form_data = {**page_input}

--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -34,7 +34,7 @@ from .decorators import (
     is_inspectors,
     is_preparators,
     is_sanctions,
-    is_sanctions_and_returns,
+    is_sanctions_and_refunds,
     is_super_admin,
 )
 from .exceptions import (
@@ -601,7 +601,7 @@ def resolve_request_for_approval(obj, info, ids):
 
 
 @mutation.field("acceptRefunds")
-@is_sanctions_and_returns
+@is_sanctions_and_refunds
 @convert_kwargs_to_snake_case
 def resolve_accept_refunds(obj, info, ids):
     request = info.context["request"]

--- a/parking_permits/decorators.py
+++ b/parking_permits/decorators.py
@@ -26,7 +26,7 @@ def user_passes_test(test_func):
 
 is_authenticated = user_passes_test(lambda u: u.is_authenticated)
 is_super_admin = user_passes_test(lambda u: u.is_super_admin)
-is_sanctions_and_returns = user_passes_test(lambda u: u.is_sanctions_and_returns)
+is_sanctions_and_refunds = user_passes_test(lambda u: u.is_sanctions_and_refunds)
 is_sanctions = user_passes_test(lambda u: u.is_sanctions)
 is_customer_service = user_passes_test(lambda u: u.is_customer_service)
 is_preparators = user_passes_test(lambda u: u.is_preparators)

--- a/parking_permits/decorators.py
+++ b/parking_permits/decorators.py
@@ -53,3 +53,4 @@ def require_user_passes_test(test_func):
 
 
 require_super_admin = require_user_passes_test(lambda u: u.is_super_admin)
+require_inspectors = require_user_passes_test(lambda u: u.is_inspectors)

--- a/parking_permits/exporters.py
+++ b/parking_permits/exporters.py
@@ -108,6 +108,15 @@ PERMIT_HEADERS = [
     _("Status"),
 ]
 
+
+LIMITED_PERMIT_HEADERS = [
+    _("Registration number"),
+    _("Parking zone"),
+    _("Start time"),
+    _("End time"),
+    _("Status"),
+]
+
 ORDER_HEADERS = [
     _("Name"),
     _("Registration number"),
@@ -138,6 +147,7 @@ PRODUCT_HEADERS = [
 
 HEADERS_MAPPING = {
     "permits": PERMIT_HEADERS,
+    "limited_permits": LIMITED_PERMIT_HEADERS,
     "orders": ORDER_HEADERS,
     "refunds": REFUND_HEADERS,
     "products": PRODUCT_HEADERS,

--- a/parking_permits/management/commands/create_group_mapping.py
+++ b/parking_permits/management/commands/create_group_mapping.py
@@ -34,7 +34,7 @@ GROUPS = [
         ],
     },
     {
-        "name": ParkingPermitGroups.SANCTIONS_AND_RETURNS,
+        "name": ParkingPermitGroups.SANCTIONS_AND_REFUNDS,
         "ad_group": "sg_kymp_pyva_asukpt_maksuseuraamukset_palautukset",
         "permissions": [
             "add_parkingpermit",

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -107,6 +107,19 @@ type PermitNode {
   primaryVehicle: Boolean!
 }
 
+type LimitedPermitNode {
+  id: ID!
+  vehicle: VehicleNode
+  parkingZone: ZoneNode
+  status: ParkingPermitStatus!
+  address: AddressNode
+  startTime: String
+  endTime: String
+  description: String
+  type: String
+  primaryVehicle: Boolean!
+}
+
 type RefundNode {
   id: ID!
   name: String
@@ -144,6 +157,11 @@ type PageInfo {
 
 type PagedPermits {
   objects: [PermitNode]
+  pageInfo: PageInfo
+}
+
+type LimitedPagedPermits {
+  objects: [LimitedPermitNode]
   pageInfo: PageInfo
 }
 
@@ -308,6 +326,11 @@ type Query {
     searchParams: PermitSearchParamsInput
    ): PagedPermits!
   permitDetail(permitId: ID!): PermitDetailNode!
+  limitedPermits(
+    pageInput: PageInput!
+    orderBy: OrderByInput
+    searchParams: PermitSearchParamsInput
+  ): LimitedPagedPermits!
   zones: [ZoneNode]
   customers(
     pageInput: PageInput!

--- a/users/models.py
+++ b/users/models.py
@@ -4,7 +4,7 @@ from helusers.models import AbstractUser
 
 class ParkingPermitGroups(models.TextChoices):
     SUPER_ADMIN = "super_admin"
-    SANCTIONS_AND_RETURNS = "sanctions_and_returns"
+    SANCTIONS_AND_REFUNDS = "sanctions_and_refunds"
     SANCTIONS = "sanctions"
     CUSTOMER_SERVICE = "customer_service"
     PREPARATORS = "preparators"
@@ -17,9 +17,9 @@ class User(AbstractUser):
         return self.groups.filter(name=ParkingPermitGroups.SUPER_ADMIN).exists()
 
     @property
-    def is_sanctions_and_returns(self):
+    def is_sanctions_and_refunds(self):
         return (
-            self.groups.filter(name=ParkingPermitGroups.SANCTIONS_AND_RETURNS).exists()
+            self.groups.filter(name=ParkingPermitGroups.SANCTIONS_AND_REFUNDS).exists()
             or self.is_super_admin
         )
 
@@ -27,7 +27,7 @@ class User(AbstractUser):
     def is_sanctions(self):
         return (
             self.groups.filter(name=ParkingPermitGroups.SANCTIONS).exists()
-            or self.is_sanctions_and_returns
+            or self.is_sanctions_and_refunds
             or self.is_super_admin
         )
 
@@ -36,7 +36,7 @@ class User(AbstractUser):
         return (
             self.groups.filter(name=ParkingPermitGroups.CUSTOMER_SERVICE).exists()
             or self.is_sanctions
-            or self.is_sanctions_and_returns
+            or self.is_sanctions_and_refunds
             or self.is_super_admin
         )
 
@@ -46,7 +46,7 @@ class User(AbstractUser):
             self.groups.filter(name=ParkingPermitGroups.PREPARATORS).exists()
             or self.is_customer_service
             or self.is_sanctions
-            or self.is_sanctions_and_returns
+            or self.is_sanctions_and_refunds
             or self.is_super_admin
         )
 
@@ -57,6 +57,6 @@ class User(AbstractUser):
             or self.is_preparators
             or self.is_customer_service
             or self.is_sanctions
-            or self.is_sanctions_and_returns
+            or self.is_sanctions_and_refunds
             or self.is_super_admin
         )

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -7,8 +7,8 @@ from users.tests.factories.user import GroupFactory, UserFactory
 class UserModelTestCase(TestCase):
     def setUp(self):
         self.admin_group = GroupFactory(name=ParkingPermitGroups.SUPER_ADMIN)
-        self.sanctions_and_returns = GroupFactory(
-            name=ParkingPermitGroups.SANCTIONS_AND_RETURNS
+        self.sanctions_and_refunds = GroupFactory(
+            name=ParkingPermitGroups.SANCTIONS_AND_REFUNDS
         )
         self.sanctions = GroupFactory(name=ParkingPermitGroups.SANCTIONS)
         self.customer_service = GroupFactory(name=ParkingPermitGroups.CUSTOMER_SERVICE)
@@ -19,17 +19,17 @@ class UserModelTestCase(TestCase):
         user = UserFactory()
         user.groups.add(self.admin_group)
         assert user.is_super_admin is True
-        assert user.is_sanctions_and_returns is True
+        assert user.is_sanctions_and_refunds is True
         assert user.is_sanctions is True
         assert user.is_customer_service is True
         assert user.is_preparators is True
         assert user.is_inspectors is True
 
-    def test_is_sanctions_and_returns(self):
+    def test_is_sanctions_and_refunds(self):
         user = UserFactory()
-        user.groups.add(self.sanctions_and_returns)
+        user.groups.add(self.sanctions_and_refunds)
         assert user.is_super_admin is False
-        assert user.is_sanctions_and_returns is True
+        assert user.is_sanctions_and_refunds is True
         assert user.is_sanctions is True
         assert user.is_customer_service is True
         assert user.is_preparators is True
@@ -39,7 +39,7 @@ class UserModelTestCase(TestCase):
         user = UserFactory()
         user.groups.add(self.sanctions)
         assert user.is_super_admin is False
-        assert user.is_sanctions_and_returns is False
+        assert user.is_sanctions_and_refunds is False
         assert user.is_sanctions is True
         assert user.is_customer_service is True
         assert user.is_preparators is True
@@ -49,7 +49,7 @@ class UserModelTestCase(TestCase):
         user = UserFactory()
         user.groups.add(self.customer_service)
         assert user.is_super_admin is False
-        assert user.is_sanctions_and_returns is False
+        assert user.is_sanctions_and_refunds is False
         assert user.is_sanctions is False
         assert user.is_customer_service is True
         assert user.is_preparators is True
@@ -59,7 +59,7 @@ class UserModelTestCase(TestCase):
         user = UserFactory()
         user.groups.add(self.preparators)
         assert user.is_super_admin is False
-        assert user.is_sanctions_and_returns is False
+        assert user.is_sanctions_and_refunds is False
         assert user.is_sanctions is False
         assert user.is_customer_service is False
         assert user.is_preparators is True
@@ -69,7 +69,7 @@ class UserModelTestCase(TestCase):
         user = UserFactory()
         user.groups.add(self.inspectors)
         assert user.is_super_admin is False
-        assert user.is_sanctions_and_returns is False
+        assert user.is_sanctions_and_refunds is False
         assert user.is_sanctions is False
         assert user.is_customer_service is False
         assert user.is_preparators is False
@@ -78,7 +78,7 @@ class UserModelTestCase(TestCase):
     def test_if_no_valid_groups_it_should_return_false(self):
         user = UserFactory()
         assert user.is_super_admin is False
-        assert user.is_sanctions_and_returns is False
+        assert user.is_sanctions_and_refunds is False
         assert user.is_sanctions is False
         assert user.is_customer_service is False
         assert user.is_preparators is False


### PR DESCRIPTION
## Description

Role base access control admin UI

## Context

UI differences between admin roles:

### super_admin

- All tabs and all functions visible

### sanctions_and_returns

- Only show permits, orders and refunds tabs

- Refund-tab with both “Request for approval“- and “Accept refunds“-buttons

### sanctions

- Only show permits, orders and refunds tabs

- Refund-tab with only “Request for approval“ button

- (Optional: hide checkboxes from “Awaiting approval” status rows in returns, because they aren’t functional for this role)

### customer_service

- Only show permits, orders and refunds tabs

- In returns tab:

  - Hide sticky bottom with buttons
  
  - Hide checkboxes and “select all” function

### preparators

- Only show permits, orders and refunds tabs

- In permits tab, hide all buttons except “download as pdf”

- In returns tab, once a single return is opened:

- Change the input fields of name and IBAN to disabled – read only

- Hide buttons “save” and “cancel”

### inspectors

- Only show permits tab

- Don’t show personal information in the table

- Ensure the downloadable .csv doesn’t include personal information

- Once a permit is opened:

  - In the “Customer information” column in the middle, only show “Parking zone” information
  
  - Hide “Change history” in the bottom
  
  - Hide all the buttons in the bottom, also the .pdf download button


[PV-280](https://helsinkisolutionoffice.atlassian.net/browse/PV-280)

