### PR TITLE
Use original permit start time for validity start

### DIFF
--- a/parking_permits/templates/emails/temporary_vehicle_deactivated.html
+++ b/parking_permits/templates/emails/temporary_vehicle_deactivated.html
@@ -15,7 +15,7 @@
         {% translate "Area" %}: {{ permit.parking_zone.name }} <br>
         {% translate "Vehicle" %}: {{ permit.vehicle }}<br>
         {{ permit.get_contract_type_display }} <br>
-        {% translate "Validity period" %}: {{ permit.active_temporary_vehicle.end_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
+        {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
     </p>
     <p>
         {% translate "The parking permit is electronic and parking permit enforcers will identify permit validity based on your vehicle licence plate number." %}


### PR DESCRIPTION
## Description

Use original permit start time for validity start when temporary vehicle is deactivated.