### PR TITLE
Update Talpa-checkout layout

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -180,7 +180,7 @@ class CustomerPermit:
                     parking_zone=address.zone,
                     primary_vehicle=primary_vehicle,
                     contract_type=contract_type,
-                    start_time=next_day(),
+                    start_time=tz.now(),
                     end_time=end_time,
                     vehicle=Vehicle.objects.get(registration_number=registration),
                 )

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -1,5 +1,6 @@
 import calendar
-from collections import Callable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Callable
 from itertools import chain
 
 from ariadne import convert_camel_case_to_snake

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -1,10 +1,55 @@
 import calendar
+from collections import Callable, OrderedDict
 from itertools import chain
 
 from ariadne import convert_camel_case_to_snake
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from pytz import utc
+
+
+class DefaultOrderedDict(OrderedDict):
+    def __init__(self, default_factory=None, *a, **kw):
+        if default_factory is not None and not isinstance(default_factory, Callable):
+            raise TypeError("first argument must be callable")
+        OrderedDict.__init__(self, *a, **kw)
+        self.default_factory = default_factory
+
+    def __getitem__(self, key):
+        try:
+            return OrderedDict.__getitem__(self, key)
+        except KeyError:
+            return self.__missing__(key)
+
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = value = self.default_factory()
+        return value
+
+    def __reduce__(self):
+        if self.default_factory is None:
+            args = tuple()
+        else:
+            args = (self.default_factory,)
+        return type(self), args, None, None, self.items()
+
+    def copy(self):
+        return self.__copy__()
+
+    def __copy__(self):
+        return type(self)(self.default_factory, self)
+
+    def __deepcopy__(self, memo):
+        import copy
+
+        return type(self)(self.default_factory, copy.deepcopy(self.items()))
+
+    def __repr__(self):
+        return "OrderedDefaultDict(%s, %s)" % (
+            self.default_factory,
+            OrderedDict.__repr__(self),
+        )
 
 
 def diff_months_floor(start_date, end_date):


### PR DESCRIPTION
## Description

Currently we do not support multiple dynamic products and chronological order items with separately calculated VAT-amounts and sums. This PR adds support for all these.

## Context

Fixes: [PV-484](https://helsinkisolutionoffice.atlassian.net/browse/PV-484), [PV-476](https://helsinkisolutionoffice.atlassian.net/browse/PV-476)

## How Has This Been Tested?

Manually, by creating complex scenarios with multiple permits that spans multiple product price ranges and uses different low-emission statuses. Observing that the Talpa-checkout output is correct.

## Manual Testing Instructions for Reviewers

Try to do the same.

## Screenshots

![talpa-checkout](https://user-images.githubusercontent.com/2784933/199794411-53e19caf-225c-4b98-974a-768c9a02ce61.png)

![talpa-checkout-2](https://user-images.githubusercontent.com/2784933/199795048-1d71d7fa-f8e0-4b68-b8a5-6ea02979ae44.png)


