### PR TITLE
Fix second vehicle adding

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -389,7 +389,7 @@ class CustomerPermit:
         # multiple zone.
         if self.customer_permit_query.count():
             primary, _ = self._get_primary_and_secondary_permit()
-            if str(primary.address_id) != address_id and primary.status != DRAFT:
+            if primary.address_id != address_id and primary.status != DRAFT:
                 raise InvalidUserAddress(
                     f"You can buy permit only for address {primary.address}"
                 )


### PR DESCRIPTION
## Description

Currently adding second vehicle does not work when user has already bought one permit.
Fix by using correct type in comparison.

Fixes: [PV-474](https://helsinkisolutionoffice.atlassian.net/browse/PV-474)

## How Has This Been Tested?

Manually by adding second vehicle when user already has one permit.

## Manual Testing Instructions for Reviewers

Try to add second vehicle when user already has one permit.

## Screenshots

![add-vehicle](https://user-images.githubusercontent.com/2784933/199920819-03634848-cdfe-41ee-a998-006adc37f2a3.png)

