### PR TITLE
Fix: Add audit_logger to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 !users*
 !locale*
 !etc-pki-entitlement*
+!audit_logger*
 
 #################################################
 # Allowed files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 as base
 
 WORKDIR /app
 
@@ -6,6 +6,8 @@ RUN apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false upd
     TZ="Europe/Helsinki" DEBIAN_FRONTEND=noninteractive apt-get install -y nano apt-transport-https python3-pip gdal-bin uwsgi uwsgi-plugin-python3 libgdal26 git-core postgresql-client netcat gettext libpq-dev unzip && \
     ln -s /usr/bin/pip3 /usr/local/bin/pip && \
     ln -s /usr/bin/python3 /usr/local/bin/python
+
+FROM base
 
 COPY requirements.txt .
 
@@ -17,7 +19,7 @@ ENV STATIC_ROOT /srv/app/static
 RUN mkdir -p /srv/app/static
 
 RUN DJANGO_SECRET_KEY="only-used-for-collectstatic" DATABASE_URL="sqlite:///" \
-    python /app/manage.py collectstatic --noinput
+    python manage.py collectstatic --noinput
 
 
 RUN DJANGO_SECRET_KEY="only-used-for-collectstatic" DATABASE_URL="sqlite:///" \


### PR DESCRIPTION
## Description

Adds audit_logger to `.dockerignore`. Also made the Ubuntu package install into its own build stage since it takes forever and doesn't change that often.

## Context

Build pipeline is broken. This fixes it.

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Run `docker build .` locally. If it passes, it should probably work in the pipeline as well.
