### PR TITLE
Fix: Change VehiclePowerTypeNode's identifier type to String!

### DIFF
--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -57,7 +57,7 @@ type CustomerNode {
 
 type VehiclePowerTypeNode {
   name: String!
-  identifier: CustomerNode!
+  identifier: String!
 }
 
 type VehicleNode {


### PR DESCRIPTION
## Description

Change `VehiclePowerTypeNode`'s `identifier` type to `String!` (from `CustomerNode!`)

## Context

`identifier`'s type is wrong (it's a `CharField` in the model, so it should not have anything to do with a customer). This fixes it.
