### PR TITLE
Reset the month count for permits if primary vehicle is changed

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -425,9 +425,19 @@ class CustomerPermit:
         if not secondary:
             return [primary]
         primary.primary_vehicle = secondary.primary_vehicle
-        primary.save(update_fields=["primary_vehicle"])
+
+        update_fields = ["primary_vehicle"]
+        if primary.contract_type == ContractType.FIXED_PERIOD:
+            primary.end_time = get_end_time(primary.start_time, 1)
+            secondary.end_time = get_end_time(primary.start_time, 1)
+            primary.month_count = 1
+            secondary.month_count = 1
+            update_fields.append("end_time")
+            update_fields.append("month_count")
+
+        primary.save(update_fields=update_fields)
         secondary.primary_vehicle = not secondary.primary_vehicle
-        secondary.save(update_fields=["primary_vehicle"])
+        secondary.save(update_fields=update_fields)
         return primary, secondary
 
     # Start time will be next day by default if the type is immediately


### PR DESCRIPTION
## Description
If the primary vehicle of the user changes it should reset the month count counter in order to remove the complexity of secondary permit having month count greater than primary permit.

[PV-475](https://helsinkisolutionoffice.atlassian.net/browse/PV-475)

## Manual Testing Instructions for Reviewers

From webshop create two draft permits and add some duration to the both of them. Then go back to previous step and change the primary vehicle.

## Screenshots
![Nov-08-2022 23-09-04](https://user-images.githubusercontent.com/9328930/200677419-5b5ac630-bb2f-4da3-b2e8-661d1884903a.gif)

