### PR TITLE
Fix: Fix vehicle power type in vehicle update/create

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -60,6 +60,7 @@ from .forms import (
 from .models.order import OrderStatus
 from .models.parking_permit import ContractType
 from .models.refund import RefundStatus
+from .models.vehicle import VehiclePowerType
 from .reversion import EventType, get_obj_changelogs, get_reversion_comment
 from .services.dvv import get_person_info
 from .services.mail import (
@@ -230,6 +231,13 @@ def update_or_create_customer(customer_info):
 
 
 def update_or_create_vehicle(vehicle_info):
+    try:
+        power_type = VehiclePowerType.objects.get(
+            identifier=vehicle_info["power_type"]["identifier"]
+        )
+    except VehiclePowerType.DoesNotExist:
+        raise ObjectNotFound(_("Vehicle power type not found"))
+
     vehicle_data = {
         "registration_number": vehicle_info["registration_number"],
         "manufacturer": vehicle_info["manufacturer"],
@@ -240,7 +248,7 @@ def update_or_create_vehicle(vehicle_info):
         "euro_class": vehicle_info["euro_class"],
         "emission": vehicle_info["emission"],
         "emission_type": vehicle_info["emission_type"],
-        "power_type": vehicle_info["power_type"],
+        "power_type": power_type,
     }
     return Vehicle.objects.update_or_create(
         registration_number=vehicle_info["registration_number"], defaults=vehicle_data

--- a/parking_permits/tests/test_admin_resolvers.py
+++ b/parking_permits/tests/test_admin_resolvers.py
@@ -1,0 +1,118 @@
+import pytest
+
+from parking_permits.admin_resolvers import update_or_create_vehicle
+from parking_permits.exceptions import ObjectNotFound
+from parking_permits.tests.factories.vehicle import (
+    VehicleFactory,
+    VehiclePowerTypeFactory,
+)
+
+
+@pytest.mark.django_db
+def test_update_or_create_vehicle_should_create_vehicle():
+    power_type = VehiclePowerTypeFactory()
+    vehicle_info = dict(
+        registration_number="ABC-123",
+        manufacturer="Manufacturer",
+        model="Model",
+        consent_low_emission_accepted=True,
+        serial_number="123",
+        vehicle_class="M1",
+        euro_class=1,
+        emission=1,
+        emission_type="WLTP",
+        power_type={"identifier": power_type.identifier},
+    )
+
+    vehicle = update_or_create_vehicle(vehicle_info)
+
+    skipped_keys = ["power_type"]
+    for k, v in vehicle_info.items():
+        if k in skipped_keys:
+            continue
+        assert getattr(vehicle, k) == v
+    assert vehicle.power_type == power_type
+
+
+@pytest.mark.django_db
+def test_update_or_create_vehicle_should_update_vehicle():
+    old_power_type = VehiclePowerTypeFactory()
+    new_power_type = VehiclePowerTypeFactory()
+    old_vehicle = VehicleFactory(
+        registration_number="ABC-123",
+        power_type=old_power_type,
+        manufacturer="jkhlkhjlhljk",
+        model="jhkllhjkhljk",
+        consent_low_emission_accepted=False,
+        serial_number="khjlkhjhjlk",
+        vehicle_class="M2",
+        euro_class=10000,
+        emission=10000,
+        emission_type="NEDC",
+    )
+    vehicle_info = dict(
+        registration_number="ABC-123",
+        manufacturer="Manufacturer",
+        model="Model",
+        consent_low_emission_accepted=True,
+        serial_number="123",
+        vehicle_class="M1",
+        euro_class=1,
+        emission=1,
+        emission_type="WLTP",
+        power_type={"identifier": new_power_type.identifier},
+    )
+
+    new_vehicle = update_or_create_vehicle(vehicle_info)
+
+    assert new_vehicle.id == old_vehicle.id
+    skipped_keys = ["registration_number", "power_type"]
+    # A bit excessive, but whatever.
+    for k, v in vehicle_info.items():
+        if k in skipped_keys:
+            continue
+        assert getattr(old_vehicle, k) != getattr(new_vehicle, k)
+        assert getattr(new_vehicle, k) == v
+
+    assert old_vehicle.power_type != new_vehicle.power_type
+    assert new_vehicle.power_type == new_power_type
+
+
+@pytest.mark.django_db
+def test_update_or_create_vehicle_should_raise_error_if_power_type_identifier_is_missing():
+    vehicle_info = dict(
+        registration_number="ABC-123",
+        manufacturer="Manufacturer",
+        model="Model",
+        consent_low_emission_accepted=True,
+        serial_number="123",
+        vehicle_class="M1",
+        euro_class=1,
+        emission=1,
+        emission_type="WLTP",
+        power_type={"name": "bar"},
+    )
+
+    with pytest.raises(KeyError):
+        update_or_create_vehicle(vehicle_info)
+
+
+@pytest.mark.django_db
+def test_update_or_create_vehicle_should_raise_error_if_power_type_is_not_found():
+    VehiclePowerTypeFactory(identifier="01")
+    vehicle_info = dict(
+        registration_number="ABC-123",
+        manufacturer="Manufacturer",
+        model="Model",
+        consent_low_emission_accepted=True,
+        serial_number="123",
+        vehicle_class="M1",
+        euro_class=1,
+        emission=1,
+        emission_type="WLTP",
+        power_type={"identifier": "banana"},
+    )
+
+    with pytest.raises(ObjectNotFound) as exc_info:
+        update_or_create_vehicle(vehicle_info)
+    assert "Vehicle power type not found" in str(exc_info.value)


### PR DESCRIPTION
## Description

Gets the correct value for power type (`VehiclePowerType` instance from database) when updating/creating a vehicle. Also added missing unit tests for the function that actually does that.

## Context

Resident permit update doesn't work. This needs fixing.

## How Has This Been Tested?

Locally, with unit tests.

## Manual Testing Instructions for Reviewers

Unit tests should cover this, but if you want to be extra sure, try creating/updating a resident permit through the admin UI. There's another issue in the front-end though which might affect this (if you update a permit without changing the power type, it goes boom).
