### PR TITLE
Explicitly update also permit address

### DIFF
--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -441,7 +441,8 @@ def resolve_change_address(_, info, address_id, iban=None):
     open_ended_permits = permits.open_ended()
     open_ended_permits.update(parking_zone=new_zone, address=address)
 
-    permits = ParkingPermit.objects.active().filter(customer=customer)
+    # Get the updated permits.
+    permits = permits.all()
     for permit in permits:
         send_permit_email(PermitEmailType.UPDATED, permit)
 

--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -411,7 +411,7 @@ def resolve_change_address(_, info, address_id, iban=None):
         # update permit to the new zone before creating
         # new order as the price is determined by the
         # new zone
-        fixed_period_permits.update(parking_zone=new_zone)
+        fixed_period_permits.update(parking_zone=new_zone, address=address)
 
         new_order = Order.objects.create_renewal_order(
             customer, status=new_order_status
@@ -439,8 +439,9 @@ def resolve_change_address(_, info, address_id, iban=None):
     # as talpa will get the updated price based on new zone when
     # asking permit price for next month
     open_ended_permits = permits.open_ended()
-    open_ended_permits.update(parking_zone=new_zone)
+    open_ended_permits.update(parking_zone=new_zone, address=address)
 
+    permits = ParkingPermit.objects.active().filter(customer=customer)
     for permit in permits:
         send_permit_email(PermitEmailType.UPDATED, permit)
 


### PR DESCRIPTION
## Description

During the permit address change process permit address was not actually updated correctly, only zone.
As a result, user got permit update confirmation email with incorrect address information.
This fixes it.

Fixes: [PV-467](https://helsinkisolutionoffice.atlassian.net/browse/PV-467)

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Change address and observe the output.