### PR TITLE
Adjust CSV- and PDF-export lowest role to be preparator

### DIFF
--- a/parking_permits/decorators.py
+++ b/parking_permits/decorators.py
@@ -54,3 +54,4 @@ def require_user_passes_test(test_func):
 
 require_super_admin = require_user_passes_test(lambda u: u.is_super_admin)
 require_inspectors = require_user_passes_test(lambda u: u.is_inspectors)
+require_preparators = require_user_passes_test(lambda u: u.is_preparators)

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -24,7 +24,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .decorators import require_inspectors, require_super_admin
+from .decorators import require_preparators
 from .exceptions import ParkkihubiPermitError
 from .exporters import DataExporter, PdfExporter
 from .forms import (
@@ -270,7 +270,7 @@ class ParkingPermitsGDPRAPIView(ParkingPermitGDPRAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-@require_inspectors
+@require_preparators
 @require_safe
 def csv_export(request, data_type):
     form_class = {
@@ -306,7 +306,7 @@ def csv_export(request, data_type):
     return response
 
 
-@require_super_admin
+@require_preparators
 @require_safe
 def pdf_export(request):
     form = PdfExportForm(request.GET)


### PR DESCRIPTION
## Description

Adjust CSV- and PDF-export lowest role to be preparator as per original specification.

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Test with preparator role and observe outputs.
