### PR TITLE
Refund should be created for an open ended permit if not started

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -312,10 +312,12 @@ class CustomerPermit:
             total_sum = sum(
                 [permit.get_refund_amount_for_unused_items() for permit in permits]
             )
-            if total_sum > 0:
+            first_permit = permits.first()
+            refund = Refund.objects.filter(order=first_permit.latest_order)
+            if total_sum > 0 and not refund.exists():
                 refund = Refund.objects.create(
                     name=str(self.customer),
-                    order=permits.first().latest_order,
+                    order=first_permit.latest_order,
                     amount=total_sum,
                     iban=iban,
                     description=f"Refund for ending permits {','.join([str(permit.id) for permit in permits])}",


### PR DESCRIPTION
## Description

System should create a refund for an open ended contract only if the permit hasn't been started yet.

[PV-492](https://helsinkisolutionoffice.atlassian.net/browse/PV-492)

## Manual Testing Instructions for Reviewers

Login to webshop and create and open ended permit whose start time is in future. And once the payment is done try ending the permit.