### PR TITLE
Fix Admin UI create permit issues

### DIFF
--- a/parking_permits/services/traficom.py
+++ b/parking_permits/services/traficom.py
@@ -26,9 +26,10 @@ VEHICLE_SEARCH = 841
 DRIVING_LICENSE_SEARCH = 890
 
 POWER_TYPE_MAPPER = {
-    "01": "BENSIN",
-    "02": "DIESEL",
-    "04": "ELECTRIC",
+    "01": "Bensin",
+    "02": "Diesel",
+    "03": "Bifuel",
+    "04": "Electric",
 }
 
 VEHICLE_SUB_CLASS_MAPPER = {

--- a/parking_permits/tests/models/test_order.py
+++ b/parking_permits/tests/models/test_order.py
@@ -70,13 +70,13 @@ class TestOrderManager(TestCase):
         end_time = get_end_time(start_time, 6)  # end at CURRENT_YEAR-09-14 23:59
 
         high_emission_vehicle = VehicleFactory(
-            power_type=VehiclePowerTypeFactory(identifier="01", name="BENSIN"),
+            power_type=VehiclePowerTypeFactory(identifier="01", name="Bensin"),
             emission=100,
             euro_class=6,
             emission_type=EmissionType.WLTP,
         )
         low_emission_vehicle = VehicleFactory(
-            power_type=VehiclePowerTypeFactory(identifier="01", name="BENSIN"),
+            power_type=VehiclePowerTypeFactory(identifier="01", name="Bensin"),
             emission=70,
             euro_class=6,
             emission_type=EmissionType.WLTP,

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -482,7 +482,7 @@ class ParkingZoneTestCase(TestCase):
         end_time = get_end_time(start_time, 12)
 
         low_emission_vehicle = VehicleFactory(
-            power_type=VehiclePowerTypeFactory(identifier="01", name="BENSIN"),
+            power_type=VehiclePowerTypeFactory(identifier="01", name="Bensin"),
             emission=70,
             euro_class=6,
             emission_type=EmissionType.WLTP,

--- a/parking_permits/tests/models/test_vehicle.py
+++ b/parking_permits/tests/models/test_vehicle.py
@@ -18,7 +18,7 @@ from parking_permits.tests.factories.vehicle import (
 @freeze_time(datetime.datetime(2020, 6, 1))
 class TestIsLowEmissionVehicle(TestCase):
     def setUp(self):
-        self.power_type_diesel = VehiclePowerTypeFactory(name="DIESEL", identifier="02")
+        self.power_type_diesel = VehiclePowerTypeFactory(name="Diesel", identifier="02")
         self.lec = LowEmissionCriteriaFactory(
             nedc_max_emission_limit=100,
             wltp_max_emission_limit=100,
@@ -48,7 +48,7 @@ class TestIsLowEmissionVehicle(TestCase):
 
     def test_should_return_true_if_power_type_is_electric(self):
         vehicle = VehicleFactory(
-            power_type=VehiclePowerTypeFactory(name="ELECTRIC", identifier="04"),
+            power_type=VehiclePowerTypeFactory(name="Electric", identifier="04"),
         )
 
         self.assertIsLowEmissionVehicle(vehicle, True)
@@ -115,7 +115,7 @@ class TestIsLowEmissionVehicle(TestCase):
 class TestVehicle(TestCase):
     def test_should_update_is_low_emission_field_on_save(self):
         vehicle = VehicleFactory(
-            power_type=VehiclePowerTypeFactory(name="DIESEL", identifier="02"),
+            power_type=VehiclePowerTypeFactory(name="Diesel", identifier="02"),
         )
         LowEmissionCriteria.objects.all().delete()
 
@@ -123,7 +123,7 @@ class TestVehicle(TestCase):
         self.assertFalse(vehicle.is_low_emission)
         self.assertFalse(vehicle._is_low_emission)
 
-        vehicle.power_type = VehiclePowerTypeFactory(name="ELECTRIC", identifier="04")
+        vehicle.power_type = VehiclePowerTypeFactory(name="Electric", identifier="04")
 
         # Only the computed property should be true at this point.
         self.assertTrue(vehicle.is_low_emission)

--- a/parking_permits/tests/test_customer_permit.py
+++ b/parking_permits/tests/test_customer_permit.py
@@ -70,7 +70,7 @@ class GetCustomerPermitTestCase(TestCase):
             first_name="Firstname B", last_name="Lastname B"
         )
         self.zone = ParkingZoneFactory()
-        power_type = VehiclePowerTypeFactory(identifier="01", name="BENSIN")
+        power_type = VehiclePowerTypeFactory(identifier="01", name="Bensin")
         self.vehicle_a = VehicleFactory(power_type=power_type)
         self.vehicle_b = VehicleFactory(power_type=power_type)
         self.vehicle_c = VehicleFactory(power_type=power_type)
@@ -151,7 +151,7 @@ class CreateCustomerPermitTestCase(TestCase):
         )
         self.customer_a_zone = self.customer_a.primary_address.zone
         self.zone = ParkingZoneFactory()
-        power_type = VehiclePowerTypeFactory(identifier="01", name="BENSIN")
+        power_type = VehiclePowerTypeFactory(identifier="01", name="Bensin")
         self.vehicle_a = VehicleFactory(power_type=power_type)
         ProductFactory(
             zone=self.zone,


### PR DESCRIPTION
## Description

Admin UI permit creation was failing due to price resolving failures.

Now the logic is updated as follows:
- If vehicle is not found from the db, do nothing.
- If vehicle is found from the db, then use admin permit form data to update vehicle details and use that new data to resolve prices correctly.

Also use Traficom equivalent power type values for simplicity sake.

Fixes:
- [PV-499](https://helsinkisolutionoffice.atlassian.net/browse/PV-499)
- [PV-500](https://helsinkisolutionoffice.atlassian.net/browse/PV-500)

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Create permit in Admin UI, change vehicles and change all vehicle settings. Dynamic real-time price change calculations should work now.
