### PR TITLE
Use current timestamp in low-emission discount emails

### DIFF
--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -385,7 +385,7 @@ def resolve_update_permit_vehicle(
             refund = Refund.objects.create(
                 name=str(customer),
                 order=new_order,
-                amount=permit_total_price_change,
+                amount=-permit_total_price_change,
                 iban=iban if iban else "",
                 description=f"Refund for updating permits zone (customer switch vehicle to: {new_vehicle})",
             )

--- a/parking_permits/templates/emails/vehicle_low_emission_discount_activated.html
+++ b/parking_permits/templates/emails/vehicle_low_emission_discount_activated.html
@@ -10,6 +10,6 @@
     <p>
         {% translate "Vehicle" %}: {{ permit.vehicle.registration_number }}<br>
         {% translate "Discount: Low-emission vehicle" %} <br>
-        {% translate "Discount valid from" %}: {{ permit.start_time|date:"j.n.Y, H:i" }}
+        {% translate "Discount valid from" %}: {% now "j.n.Y, H:i" %}
     </p>
 {% endblock %}

--- a/parking_permits/templates/emails/vehicle_low_emission_discount_deactivated.html
+++ b/parking_permits/templates/emails/vehicle_low_emission_discount_deactivated.html
@@ -9,6 +9,6 @@
     </p>
     <p>
         {% translate "Vehicle" %}: {{ permit.vehicle.registration_number }}<br>
-        {% translate "Discount right ends" %}: {{ permit.end_time|date:"j.n.Y, H:i" }}
+        {% translate "Discount right ends" %}: {% now "j.n.Y, H:i" %}
     </p>
 {% endblock %}


### PR DESCRIPTION
## Description

It is not needed to use permit times in low-emission discount emails.
Use now instead.

Also fix refund amount to be positive.

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Can be tested locally.
