### PR TITLE
Validate temporary vehicle start time

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-11 14:52+0200\n"
+"POT-Creation-Date: 2022-11-19 08:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -109,6 +109,9 @@ msgid "Announcement not found"
 msgstr ""
 
 msgid "You already have a valid permit for a given vehicle."
+msgstr ""
+
+msgid "Temporary vehicle start time has to be after permit start time"
 msgstr ""
 
 msgid "Can not have more than 2 temporary vehicles in 365 days from first one."
@@ -736,6 +739,12 @@ msgid "Address not found"
 msgstr ""
 
 msgid "No active permits for the customer"
+msgstr ""
+
+msgid "Start time cannot be in the past"
+msgstr ""
+
+msgid "Customer does not have a valid driving licence for this vehicle"
 msgstr ""
 
 msgid "Conflict parking zones for active permits"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-11 09:45+0200\n"
+"POT-Creation-Date: 2022-11-19 08:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,6 +69,9 @@ msgstr "Asiakkaan hakuvirhe"
 msgid "Vehicle not found for the customer"
 msgstr "Asiakkaan ajoneuvoa ei löytynyt"
 
+msgid "Vehicle power type not found"
+msgstr "Ajoneuvon käyttövoimatyyppiä ei löytynyt"
+
 msgid "Cannot create more than 2 permits"
 msgstr "Asukaspysäköintitunnusten maksimimäärä on 2 kpl per asiakas"
 
@@ -107,6 +110,9 @@ msgstr "Ilmoitusta ei löytynyt"
 
 msgid "You already have a valid permit for a given vehicle."
 msgstr "Sinulla on jo voimassa oleva pysäköintitunnus kyseiselle ajoneuvolle."
+
+msgid "Temporary vehicle start time has to be after permit start time"
+msgstr "Tilapäisen ajoneuvon alkamisaika tulee olla tunnuksen alkamisajan jälkeinen"
 
 msgid "Can not have more than 2 temporary vehicles in 365 days from first one."
 msgstr ""
@@ -738,6 +744,12 @@ msgstr "Osoitetta ei löytynyt"
 
 msgid "No active permits for the customer"
 msgstr "Asiakkaalla ei ole aktiivisia tunnuksia"
+
+msgid "Start time cannot be in the past"
+msgstr "Aloitusaika ei voi olla menneisyydessä"
+
+msgid "Customer does not have a valid driving licence for this vehicle"
+msgstr "Puutteelliset ajokorttitiedot tälle ajoneuvolle"
 
 msgid "Conflict parking zones for active permits"
 msgstr "Pysäköintialueiden ja aktiivisten tunnusten konfliktitilanne"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-11 09:52+0200\n"
+"POT-Creation-Date: 2022-11-19 08:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,10 +36,8 @@ msgstr ""
 msgid "Fatal"
 msgstr ""
 
-#, fuzzy
-#| msgid "Last name"
 msgid "Logger name"
-msgstr "Efternamn"
+msgstr ""
 
 msgid "Logging level"
 msgstr ""
@@ -54,7 +52,7 @@ msgid "Created at"
 msgstr "Skapad kl"
 
 msgid "Permit search error"
-msgstr ""
+msgstr "Tillåt sökfel"
 
 msgid "No parking zone found for the location"
 msgstr "Det finns inte parkering zon för det plats"
@@ -65,13 +63,14 @@ msgstr "Flera parkerings zon till denna plats"
 msgid "Person not found"
 msgstr "Ingen kund hittas"
 
-#, fuzzy
-#| msgid "Customer service contact info"
 msgid "Customer search error"
-msgstr "Kundtjänst kontaktuppgifter"
+msgstr "Kundsökningsfel"
 
 msgid "Vehicle not found for the customer"
 msgstr "Fordonet hjittasdes inte för kunden"
+
+msgid "Vehicle power type not found"
+msgstr "Fordonskraftstyp hittades inte"
 
 msgid "Cannot create more than 2 permits"
 msgstr "Kan inte skapa mer än 2 boendeparkeringpermit"
@@ -88,78 +87,71 @@ msgid "Cannot change the customer of the permit"
 msgstr "Kunden kan inte bytas till detta parkeringstecken"
 
 msgid "IBAN is not provided"
-msgstr ""
+msgstr "IBAN tillhandahålls inte"
 
 msgid "Product search error"
-msgstr ""
+msgstr "Produktsökningsfel"
 
 msgid "Refund search error"
-msgstr ""
+msgstr "Sökningsfel för återbetalning"
 
-#, fuzzy
-#| msgid "Person not found"
 msgid "Refund not found"
-msgstr "Ingen kund hittas"
+msgstr "Återbetalning hittades inte"
 
 msgid "Order search error"
-msgstr ""
+msgstr "Beställningssökningsfel"
 
-#, fuzzy
-#| msgid "Address security ban"
 msgid "Address search error"
-msgstr "Spärrmarkering"
+msgstr "Adresssökningsfel"
 
 msgid "Announcement search error"
-msgstr ""
+msgstr "Sökningsfel för meddelande"
 
-#, fuzzy
-#| msgid "Person not found"
 msgid "Announcement not found"
-msgstr "Ingen kund hittas"
+msgstr "Meddelandet hittades inte"
 
 msgid "You already have a valid permit for a given vehicle."
-msgstr ""
+msgstr "Du har redan ett giltigt tillstånd för ett visst fordon"
+
+msgid "Temporary vehicle start time has to be after permit start time"
+msgstr "Tillfällig starttid för fordon måste vara efter tillståndets starttid"
 
 msgid "Can not have more than 2 temporary vehicles in 365 days from first one."
-msgstr ""
+msgstr "Kan inte ha mer än 2 tillfälliga fordon under 365 dagar från det första."
 
 msgid "Permit for a given vehicle already exist."
-msgstr ""
+msgstr "Tillstånd för ett givet fordon finns redan."
 
 #, python-format
 msgid "Customer is not an owner or holder of a vehicle %(registration)s"
-msgstr ""
+msgstr "Kunden är inte ägare eller innehavare av ett fordon %(registration)s"
 
 msgid "Customer does not have a valid driving licence"
-msgstr ""
+msgstr "Kunden har inte giltigt körkort"
 
 msgid "Non draft permit can not be deleted"
-msgstr ""
+msgstr "Icke utkast till tillstånd kan inte raderas"
 
-#, fuzzy
-#| msgid "Contract type"
 msgid "Contract type is required"
-msgstr "Kontraktstyp"
+msgstr "Kontraktstyp krävs"
 
 #, python-format
 msgid "Only %(fixed_period)s is allowed"
-msgstr ""
+msgstr "Endast %(fixed_period)s är tillåtet"
 
 msgid "This is not a draft permit and can not be edited"
-msgstr ""
+msgstr "Detta är inte ett utkast till tillstånd och kan inte redigeras"
 
-#, fuzzy
-#| msgid "Not a valid customer address"
 msgid "Invalid user address."
-msgstr "Inte en giltig kundadress"
+msgstr "Ogiltig användaradress."
 
 #, python-format
 msgid "You can have a max of %(max_allowed_permit)s permits."
-msgstr ""
+msgstr "Du kan ha maximalt %(max_allowed_permit)s tillstånd."
 
 #, python-format
 msgid "You can buy permit only for address %(primary_address)s."
-msgstr ""
+msgstr "Du kan endast köpa tillstånd för adressen %(primary_address)s."
 
 msgid "Name"
 msgstr "Namn"
@@ -681,15 +673,11 @@ msgstr "NEDC"
 msgid "WLTP"
 msgstr "WLTP"
 
-#, fuzzy
-#| msgid "Vehicle user"
 msgid "Vehicle power type"
-msgstr "Fordonsanvändare"
+msgstr "Fordonskraftstyp"
 
-#, fuzzy
-#| msgid "Vehicle users"
 msgid "Vehicle power types"
-msgstr "Fordonsanvändarer"
+msgstr "Fordonskraftstyper"
 
 msgid "NEDC maximum emission limit"
 msgstr "NEDC maximera"
@@ -712,8 +700,6 @@ msgstr "Fordonsanvändare"
 msgid "Vehicle users"
 msgstr "Fordonsanvändarer"
 
-#, fuzzy
-#| msgid "Power type"
 msgid "power_type"
 msgstr "Drivkraft"
 
@@ -758,6 +744,12 @@ msgstr "Adressen hittades inte"
 
 msgid "No active permits for the customer"
 msgstr "Inga aktiva tillstånd för kunden"
+
+msgid "Start time cannot be in the past"
+msgstr "Starttiden kan inte ligga i det förflutna"
+
+msgid "Customer does not have a valid driving licence for this vehicle"
+msgstr "Kunden har inte ett giltigt körkort för detta fordon"
 
 msgid "Conflict parking zones for active permits"
 msgstr "Konflict för parkering zoner och aktiva tillståndet"
@@ -931,14 +923,3 @@ msgstr "Rätten till rabatt har tagits bort från fordonet."
 msgid "Discount right ends"
 msgstr "Rabatten till höger upphör"
 
-#~ msgid "Electric"
-#~ msgstr "El"
-
-#~ msgid "Bensin"
-#~ msgstr "Bensin"
-
-#~ msgid "Diesel"
-#~ msgstr "Diesel"
-
-#~ msgid "Bifuel"
-#~ msgstr "Bifuel"

--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -84,6 +84,11 @@ class CustomerPermit:
         permit_details = self._get_permit(permit_id)
         permit = permit_details[0]
 
+        if tz.localtime(isoparse(start_time)) < permit.start_time:
+            raise TemporaryVehicleValidationError(
+                _("Temporary vehicle start time has to be after permit start time")
+            )
+
         tmp_vehicles = permit.temp_vehicles.filter(
             start_time__gte=get_end_time(tz.now(), -12)
         ).order_by("-start_time")[:2]


### PR DESCRIPTION
## Description

Validate temporary vehicle start time.

Two cases:
- Temporary vehicle start time cannot be in the past (separately, to reduce Traficom query-costs)
- Temporary vehicle start time has to be after permit start time

## How Has This Been Tested?

Locally.

## Screenshots

<img width="923" alt="validation" src="https://user-images.githubusercontent.com/2784933/202839906-51d61fa4-a4bd-4e6a-87e0-e6c40ac58760.png">
