### PR TITLE
Fix permit creation issues

### DIFF
--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -90,21 +90,22 @@ class OrderManager(SerializableMixin.SerializableManager):
         for permit in permits:
             products_with_quantity = permit.get_products_with_quantities()
             for product, quantity, date_range in products_with_quantity:
-                unit_price = product.get_modified_unit_price(
-                    permit.vehicle.is_low_emission, permit.is_secondary_vehicle
-                )
-                start_date, end_date = date_range
-                OrderItem.objects.create(
-                    order=order,
-                    product=product,
-                    permit=permit,
-                    unit_price=unit_price,
-                    payment_unit_price=unit_price,
-                    vat=product.vat,
-                    quantity=quantity,
-                    start_date=start_date,
-                    end_date=end_date,
-                )
+                if quantity > 0:
+                    unit_price = product.get_modified_unit_price(
+                        permit.vehicle.is_low_emission, permit.is_secondary_vehicle
+                    )
+                    start_date, end_date = date_range
+                    OrderItem.objects.create(
+                        order=order,
+                        product=product,
+                        permit=permit,
+                        unit_price=unit_price,
+                        payment_unit_price=unit_price,
+                        vat=product.vat,
+                        quantity=quantity,
+                        start_date=start_date,
+                        end_date=end_date,
+                    )
 
         order.permits.add(*permits)
         return order

--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -440,6 +440,7 @@ def resolve_create_order(_obj, info, audit_msg: AuditMsg = None):
         customer=customer, status=ParkingPermitStatus.DRAFT
     )
     order = Order.objects.create_for_permits(permits)
+    permits.update(status=ParkingPermitStatus.PAYMENT_IN_PROGRESS)
     audit_msg.target = order
     return {"checkout_url": TalpaOrderManager.send_to_talpa(order)}
 


### PR DESCRIPTION
## Description

Currently permit creation has two issues:
- Permit status is not set to `PAYMENT_IN_PROGRESS` before regular Talpa-payment
- Order creation creates empty order items with quantity `0`, which is never needed

This PR fixes these issues.

## Context

[PV-497](https://helsinkisolutionoffice.atlassian.net/browse/PV-497)

## How Has This Been Tested?

Locally.
