### PR TITLE
Admin UI: Validate permit creation main cases

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-20 11:58+0200\n"
+"POT-Creation-Date: 2022-11-22 15:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,13 +69,31 @@ msgstr ""
 msgid "Vehicle not found for the customer"
 msgstr ""
 
+msgid "Customer without address security ban must have one address selected"
+msgstr ""
+
 msgid "Vehicle power type not found"
+msgstr ""
+
+msgid "Customer national id number is mandatory for the permit"
 msgstr ""
 
 msgid "Cannot create more than 2 permits"
 msgstr ""
 
-msgid "The validity period of secondary permit cannot exceeds the primary one"
+msgid "Vehicle registration number is mandatory for the permit"
+msgstr ""
+
+msgid "User already has a valid permit for the given vehicle."
+msgstr ""
+
+msgid "The validity period of secondary permit cannot exceed the primary one"
+msgstr ""
+
+#, python-format
+msgid ""
+"Cannot create permit. User already has a valid existing permit in zone "
+"%(parking_zone)s."
 msgstr ""
 
 msgid "Parking permit not found"
@@ -149,6 +167,12 @@ msgstr ""
 
 #, python-format
 msgid "You can buy permit only for address %(primary_address)s."
+msgstr ""
+
+msgid "Forbidden"
+msgstr ""
+
+msgid "Internal Server Error"
 msgstr ""
 
 msgid "Name"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-20 11:58+0200\n"
+"POT-Creation-Date: 2022-11-22 15:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,14 +69,34 @@ msgstr "Asiakkaan hakuvirhe"
 msgid "Vehicle not found for the customer"
 msgstr "Asiakkaan ajoneuvoa ei löytynyt"
 
+msgid "Customer without address security ban must have one address selected"
+msgstr "Ei-turvakieltoasiakkaalla tulee olla osoite valittuna"
+
 msgid "Vehicle power type not found"
 msgstr "Ajoneuvon käyttövoimatyyppiä ei löytynyt"
+
+msgid "Customer national id number is mandatory for the permit"
+msgstr "Asiakkaan henkilötunnus on pakollinen tieto"
 
 msgid "Cannot create more than 2 permits"
 msgstr "Asukaspysäköintitunnusten maksimimäärä on 2 kpl per asiakas"
 
-msgid "The validity period of secondary permit cannot exceeds the primary one"
+msgid "Vehicle registration number is mandatory for the permit"
+msgstr "Ajoneuvon rekisterinumero on pakollinen tietd"
+
+msgid "User already has a valid permit for the given vehicle."
+msgstr "Sinulla on jo voimassa oleva pysäköintitunnus kyseiselle ajoneuvolle."
+
+msgid "The validity period of secondary permit cannot exceed the primary one"
 msgstr "Toissijaisen tunnuksen aikaväli ei voi ylittää ensisijaista"
+
+#, python-format
+msgid ""
+"Cannot create permit. User already has a valid existing permit in zone "
+"%(parking_zone)s."
+msgstr ""
+"Tunnusta ei voitu luoda. Asiakkaalla on jo voimassaoleva pysäköintitunnus alueella "
+"%(parking_zone)s."
 
 msgid "Parking permit not found"
 msgstr "Pysäköintitunnusta ei löytynyt"
@@ -153,6 +173,12 @@ msgstr ""
 #, python-format
 msgid "You can buy permit only for address %(primary_address)s."
 msgstr "Voit ostaa pysäköintitunnuksen vain osoitteelle %(primary_address)s."
+
+msgid "Forbidden"
+msgstr "Lupa evätty"
+
+msgid "Internal Server Error"
+msgstr "Sisäinen virhe"
 
 msgid "Name"
 msgstr "Nimi"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-20 11:58+0200\n"
+"POT-Creation-Date: 2022-11-22 15:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,16 +69,36 @@ msgstr "Kundsökningsfel"
 msgid "Vehicle not found for the customer"
 msgstr "Fordonet hjittasdes inte för kunden"
 
+msgid "Customer without address security ban must have one address selected"
+msgstr "Kund utan adresssäkerhetsförbud måste ha en adress vald"
+
 msgid "Vehicle power type not found"
 msgstr "Fordonskraftstyp hittades inte"
+
+msgid "Customer national id number is mandatory for the permit"
+msgstr "Kundens personnummer är obligatoriskt för tillståndet"
 
 msgid "Cannot create more than 2 permits"
 msgstr "Kan inte skapa mer än 2 boendeparkeringpermit"
 
-msgid "The validity period of secondary permit cannot exceeds the primary one"
+msgid "Vehicle registration number is mandatory for the permit"
+msgstr "Fordonets registreringsnummer är obligatoriskt för tillståndet"
+
+msgid "User already has a valid permit for the given vehicle."
+msgstr "Du har redan ett giltigt tillstånd för ett visst fordon"
+
+msgid "The validity period of secondary permit cannot exceed the primary one"
 msgstr ""
 "Giltighetstiden för det sekundära permit får inte överstiga det primära "
 "permit"
+
+#, python-format
+msgid ""
+"Cannot create permit. User already has a valid existing permit in zone "
+"%(parking_zone)s."
+msgstr ""
+"Kan inte skapa tillstånd. Användaren har redan ett giltigt befintligt tillstånd i zonen "
+"%(parking_zone)s."
 
 msgid "Parking permit not found"
 msgstr "Parkeringtecken hittades inte"
@@ -153,6 +173,12 @@ msgstr "Du kan ha maximalt %(max_allowed_permit)s tillstånd."
 #, python-format
 msgid "You can buy permit only for address %(primary_address)s."
 msgstr "Du kan endast köpa tillstånd för adressen %(primary_address)s."
+
+msgid "Forbidden"
+msgstr "Förbjuden"
+
+msgid "Internal Server Error"
+msgstr "Internt fel"
 
 msgid "Name"
 msgstr "Namn"

--- a/parking_permits/error_formatter.py
+++ b/parking_permits/error_formatter.py
@@ -1,5 +1,6 @@
 from ariadne import format_error
 from django.core.exceptions import PermissionDenied
+from django.utils.translation import gettext_lazy as _
 
 from parking_permits.exceptions import ParkingPermitBaseException
 
@@ -9,7 +10,7 @@ def error_formatter(error, debug):
     if isinstance(error.original_error, ParkingPermitBaseException):
         formatted["message"] = str(error.original_error)
     elif isinstance(error.original_error, PermissionDenied):
-        formatted["message"] = "Forbidden"
+        formatted["message"] = _("Forbidden")
     else:
-        formatted["message"] = "Internal Server Error"
+        formatted["message"] = _("Internal Server Error")
     return formatted

--- a/parking_permits/services/dvv.py
+++ b/parking_permits/services/dvv.py
@@ -79,8 +79,8 @@ def format_address(address_data):
         "street_name": street_name,
         "street_name_sv": street_name_sv,
         "street_number": street_number,
-        "city_sv": address_data["PostitoimipaikkaR"],
-        "city": address_data["PostitoimipaikkaS"],
+        "city_sv": address_data["PostitoimipaikkaR"].title(),
+        "city": address_data["PostitoimipaikkaS"].title(),
         "postal_code": address_data["Postinumero"],
         "zone": zone,
     }


### PR DESCRIPTION
## Description

Validate permit creation main cases:
- Customer national id number existence
- Normal customer address existence
- Vehicle licence plate number existence
- Duplicate vehicles
- Area has to be same for all customer permits

Fix:
- Address creation on permit create
- Parkkihubi updates to work only when debug is off

[PV-508](https://helsinkisolutionoffice.atlassian.net/browse/PV-508)

## How Has This Been Tested?

Locally.

## Screenshots

![different permit zone](https://user-images.githubusercontent.com/2784933/203347711-087da9e4-992e-4021-934e-e0322c6af8fe.png)

