### PR TITLE
Add temporary vehicle support for admin view

### DIFF
--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -102,6 +102,7 @@ type PermitNode {
   id: ID!
   customer: CustomerNode!
   vehicle: VehicleNode
+  activeTemporaryVehicle: TemporaryVehicleNode
   parkingZone: ZoneNode
   status: ParkingPermitStatus!
   address: AddressNode
@@ -115,6 +116,7 @@ type PermitNode {
 type LimitedPermitNode {
   id: ID!
   vehicle: VehicleNode
+  activeTemporaryVehicle: TemporaryVehicleNode
   parkingZone: ZoneNode
   status: ParkingPermitStatus!
   address: AddressNode
@@ -234,10 +236,19 @@ type ChangeLog {
   createdBy: String!
 }
 
+type TemporaryVehicleNode {
+  id: ID!
+  vehicle: VehicleNode!
+  startTime: String!
+  endTime: String!
+  isActive: Boolean!
+}
+
 type PermitDetailNode {
   id: ID!
   customer: CustomerNode!
   vehicle: VehicleNode
+  activeTemporaryVehicle: TemporaryVehicleNode
   primaryVehicle: Boolean!
   parkingZone: ZoneNode
   status: ParkingPermitStatus!
@@ -496,6 +507,8 @@ enum PermitEndType {
 }
 
 type Mutation {
+  addTemporaryVehicle(permitId: ID!, registrationNumber: String!, startTime: String!, endTime: String!): MutationResponse!
+  removeTemporaryVehicle(permitId: ID!): MutationResponse
   createResidentPermit(permit: ResidentPermitInput!): CreatePermitResponse
   endPermit(permitId: ID!, endType: PermitEndType!, iban: String): MutationResponse
   updateResidentPermit(permitId: ID!, permitInfo: ResidentPermitInput!, iban: String): MutationResponse


### PR DESCRIPTION
## Description

Temporary vehicle support for admins.

Minimum roles required is customer service.

[PV-471](https://helsinkisolutionoffice.atlassian.net/browse/PV-471)


## Manual Testing Instructions for Reviewers

Login in to admin page with roles at least customer service. Open any valid permit and you can see a button to add a temporary vehicle.

## Screenshots

<img width="981" alt="Screenshot 2022-11-23 at 16 30 18" src="https://user-images.githubusercontent.com/9328930/203578754-af331c72-722e-4472-a918-d1feedeca30f.png">
<img width="1037" alt="Screenshot 2022-11-23 at 16 30 44" src="https://user-images.githubusercontent.com/9328930/203578762-ec975870-2e57-41f9-bfeb-1d38e5f7b356.png">
