### PR TITLE
Use Python v.3.9 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,15 @@ FROM ubuntu:20.04 as base
 WORKDIR /app
 
 RUN apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Check-Date=false update && \
-    TZ="Europe/Helsinki" DEBIAN_FRONTEND=noninteractive apt-get install -y nano apt-transport-https python3-pip gdal-bin uwsgi uwsgi-plugin-python3 libgdal26 git-core postgresql-client netcat gettext libpq-dev unzip && \
-    ln -s /usr/bin/pip3 /usr/local/bin/pip && \
-    ln -s /usr/bin/python3 /usr/local/bin/python
+    apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:deadsnakes/ppa && \
+    TZ="Europe/Helsinki" DEBIAN_FRONTEND=noninteractive apt-get install -y nano python3.9 python3.9-distutils python3.9-venv apt-transport-https gdal-bin uwsgi uwsgi-plugin-python3 libgdal26 git-core postgresql-client netcat gettext libpq-dev unzip && \
+    ln -s /usr/bin/pip3.9 /usr/local/bin/pip && \
+    ln -s /usr/bin/pip3.9 /usr/local/bin/pip3 && \
+    ln -s /usr/bin/python3.9 /usr/local/bin/python && \
+    ln -s /usr/bin/python3.9 /usr/local/bin/python3
+
+RUN python3.9 -m ensurepip
 
 FROM base
 


### PR DESCRIPTION
## Description

In Python < 3.9 type object is not subscriptable.
Use Python v.3.9 in Dockerfile to remedy this.

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Run project build and check Python version from the docker container.
