### PR TITLE
Permit emails: Use permit end time only with fixed-period permit

### DIFF
--- a/parking_permits/templates/emails/_permit_info.html
+++ b/parking_permits/templates/emails/_permit_info.html
@@ -7,5 +7,9 @@
     {% translate "Area" %}: {{ permit.parking_zone.name }} <br>
     {% translate "Vehicle" %}: {{ permit.vehicle }} <br>
     {{ permit.get_contract_type_display }} <br>
-    {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
+    {% if permit.contract_type == "FIXED_PERIOD" %}
+        {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
+    {% else %}
+        {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} –
+    {% endif %}
 </p>


### PR DESCRIPTION
## Description

Use permit end time only with fixed-period permit in emails.

## Context

[PV-505](https://helsinkisolutionoffice.atlassian.net/browse/PV-505)

## How Has This Been Tested?

With local console.
