### PR TITLE
Order partial refunds support

### DIFF
--- a/parking_permits/exceptions.py
+++ b/parking_permits/exceptions.py
@@ -58,6 +58,10 @@ class CreatePermitError(ParkingPermitBaseException):
     pass
 
 
+class EndPermitError(ParkingPermitBaseException):
+    pass
+
+
 class ProductCatalogError(ParkingPermitBaseException):
     pass
 

--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -150,7 +150,7 @@ class OrderManager(SerializableMixin.SerializableManager):
     ):
         """
         Create new order for updated permits information that affect
-        permit prices, e.g. change address or change vehicle
+        permit prices, e.g. change address or change vehicle.
         """
         customer_permits = ParkingPermit.objects.active().filter(
             contract_type=ContractType.FIXED_PERIOD, customer=customer

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -21,7 +21,6 @@ from ..exceptions import ParkkihubiPermitError, PermitCanNotBeEnded
 from ..utils import diff_months_ceil, flatten_dict, get_end_time, get_permit_prices
 from .mixins import TimestampedModelMixin, UserStampedModelMixin
 from .parking_zone import ParkingZone
-from .refund import Refund
 from .temporary_vehicle import TemporaryVehicle
 from .vehicle import Vehicle
 
@@ -464,8 +463,7 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
     def get_refund_amount_for_unused_items(self):
         total = Decimal(0)
-        refund = Refund.objects.filter(order=self.latest_order)
-        if not self.can_be_refunded or refund.exists():
+        if not self.can_be_refunded:
             return total
 
         unused_order_items = self.get_unused_order_items()

--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -311,7 +311,9 @@ def resolve_end_permit(
         audit.ModelWithId(ParkingPermit, permit_id) for permit_id in permit_ids
     ]
     request = info.context["request"]
-    return CustomerPermit(request.user.customer.id).end(permit_ids, end_type, iban)
+    return CustomerPermit(request.user.customer.id).end(
+        permit_ids, end_type, iban, request.user
+    )
 
 
 @mutation.field("getVehicleInformation")

--- a/parking_permits/talpa/order.py
+++ b/parking_permits/talpa/order.py
@@ -49,13 +49,13 @@ class TalpaOrderManager:
             "unit": "kk",
             "startDate": date_time_to_utc(order_item.permit.start_time),
             "quantity": order_item.quantity,
-            "priceNet": cls.roundUp(float(order_item.payment_unit_price_net)),
-            "priceVat": cls.roundUp(float(order_item.payment_unit_price_vat)),
-            "priceGross": cls.roundUp(float(order_item.payment_unit_price)),
-            "vatPercentage": cls.roundUp(float(order_item.vat_percentage)),
-            "rowPriceNet": cls.roundUp(float(order_item.total_payment_price_net)),
-            "rowPriceVat": cls.roundUp(float(order_item.total_payment_price_vat)),
-            "rowPriceTotal": cls.roundUp(float(order_item.total_payment_price)),
+            "priceNet": cls.round_up(float(order_item.payment_unit_price_net)),
+            "priceVat": cls.round_up(float(order_item.payment_unit_price_vat)),
+            "priceGross": cls.round_up(float(order_item.payment_unit_price)),
+            "vatPercentage": cls.round_up(float(order_item.vat_percentage)),
+            "rowPriceNet": cls.round_up(float(order_item.total_payment_price_net)),
+            "rowPriceVat": cls.round_up(float(order_item.total_payment_price_vat)),
+            "rowPriceTotal": cls.round_up(float(order_item.total_payment_price)),
             "meta": [
                 {
                     "key": "sourceOrderItemId",
@@ -160,15 +160,15 @@ class TalpaOrderManager:
         return {
             "namespace": settings.NAMESPACE,
             "user": str(order.customer.id),
-            "priceNet": cls.roundUp(float(order.total_payment_price_net)),
-            "priceVat": cls.roundUp(float(order.total_payment_price_vat)),
-            "priceTotal": cls.roundUp(float(order.total_payment_price)),
+            "priceNet": cls.round_up(float(order.total_payment_price_net)),
+            "priceVat": cls.round_up(float(order.total_payment_price_vat)),
+            "priceTotal": cls.round_up(float(order.total_payment_price)),
             "customer": customer,
             "items": items,
         }
 
     @classmethod
-    def roundUp(cls, v):
+    def round_up(cls, v):
         return "{:0.2f}".format(np.round(v, 3))
 
     @classmethod


### PR DESCRIPTION
## Description

Add support for order partial refunds to Webshop and Admin UI.
Create another renewal order for subsequent permit in the same order and create new refund for it.
Then remove order items from the renewed order to level all order and refund sums correctly.

## Context

Refs: [PV-514](https://helsinkisolutionoffice.atlassian.net/browse/PV-514)

## How Has This Been Tested?

Locally using both Webshop and Admin UI.
Orders with multiple permits can only be created through the Webshop, but individual permit ending can be accomplished from both applications.

## Manual Testing Instructions for Reviewers

Test all cases ending cases carefully and observe that orders and refunds get created correctly.

## Screenshots

![partial_refunds](https://user-images.githubusercontent.com/2784933/205338843-1a4835f2-1197-440a-9ae1-cd30a4c5c94a.png)

