### PR TITLE
Fix: Permit editing admin

### DIFF
--- a/parking_permits/admin.py
+++ b/parking_permits/admin.py
@@ -57,7 +57,7 @@ class CompanyAdmin(admin.ModelAdmin):
 @admin.register(Customer)
 class CustomerAdmin(admin.ModelAdmin):
     search_fields = ("first_name", "last_name")
-    list_display = ("__str__", "national_id_number", "email")
+    list_display = ("__str__", "id", "first_name", "last_name", "email")
     exclude = ("_national_id_number",)
 
     def has_add_permission(self, request):

--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -403,6 +403,12 @@ def update_or_create_permit_address(customer_info):
         raise AddressError(_("Permit address does not have a valid zone"))
 
 
+@query.field("addressSearch")
+@convert_kwargs_to_snake_case
+def resolve_address_earch(obj, info, search_input):
+    return kmo.search_address(search_text=search_input)
+
+
 @mutation.field("createResidentPermit")
 @is_customer_service
 @convert_kwargs_to_snake_case

--- a/parking_permits/models/customer.py
+++ b/parking_permits/models/customer.py
@@ -97,7 +97,7 @@ class Customer(SerializableMixin, TimestampedModelMixin):
         verbose_name_plural = _("Customers")
 
     def __str__(self):
-        return "%s %s" % (self.first_name, self.last_name)
+        return "%s" % self.national_id_number
 
     @property
     def age(self):

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -60,7 +60,7 @@ type CustomerNode {
 }
 
 type VehiclePowerTypeNode {
-  name: String!
+  name: String
   identifier: String!
 }
 

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -400,6 +400,7 @@ type Query {
     orderBy: OrderByInput
     searchParams: AddressSearchParamsInput
   ): PagedAddresses!
+  addressSearch(searchInput: String!): [AddressNode]
   address(addressId: ID!): AddressNode!
   lowEmissionCriteria(
     pageInput: PageInput!

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -262,6 +262,7 @@ type TemporaryVehicleNode {
 
 type PermitDetailNode {
   id: ID!
+  address: AddressNode
   customer: CustomerNode!
   vehicle: VehicleNode
   activeTemporaryVehicle: TemporaryVehicleNode
@@ -473,6 +474,8 @@ input ResidentPermitInput {
   endTime: String
   monthCount: Int
   description: String
+  address: AddressInput
+  zone: String
 }
 
 input ProductInput {

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -26,7 +26,7 @@ type ZoneNode {
 }
 
 type AddressNode {
-  id: ID!
+  id: ID
   streetName: String
   streetNumber: String
   streetNameSv: String

--- a/parking_permits/tests/test_utils.py
+++ b/parking_permits/tests/test_utils.py
@@ -95,7 +95,6 @@ def test_model_differ():
     vehicle.model = "Some other model"
     diff_dict = diff.stop()
     vehicle.registration_number = "BAR-777"
-    print(diff_dict)
     assert len(diff_dict.keys()) == 1
     assert "registration_number" in diff_dict
     assert diff_dict["registration_number"] == ("ABC-123", "FOO-321")


### PR DESCRIPTION
## Description

Permit address and zone selection on the admin view was being bit wrongly used. Permit has its own address and
zone field and it should use that in order for the permit manipulation instead of using customer address to find the correct address for a permit zone. As its impossible to know which address it will be if they belongs to same zone.


[PV-521](https://helsinkisolutionoffice.atlassian.net/browse/PV-521)


## How Has This Been Tested?

Locally

## Manual Testing Instructions for Reviewers


Login to the admin view with role greater than customer service and try to do the editing or creating of a new permit.
