### PR TITLE
Update GitHub CI Python and PostGIS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
     services:
       postgres:
-        image: postgis/postgis:11-3.1
+        image: postgis/postgis:13-3.3
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10.0"
+        python-version: "3.10.9"
     - name: Install required Ubuntu packages
       run: |
         sudo apt-get install gdal-bin


### PR DESCRIPTION
## Description

At the moment GitHub CI is using Python v.3.10.0 which is not supported anymore in GitHub.
Update it to latest Python v.3.11.1.
Also use PostGIS 13-based db-image, as we are running same version in actual service.
