### PR TITLE
PV-519: Add end time for open-ended permits' order items, show current period end time for open-ended permit exports/emails.

### DIFF
--- a/parking_permits/exporters.py
+++ b/parking_permits/exporters.py
@@ -19,12 +19,8 @@ MODEL_MAPPING = {
 
 
 def _get_permit_end_time(permit):
-    if (
-        permit.is_open_ended
-        and permit.latest_order_item
-        and permit.latest_order_item.end_time
-    ):
-        return permit.latest_order_item.end_time
+    if permit.is_open_ended:
+        return permit.current_period_end_time
     return permit.end_time
 
 

--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -9,7 +9,7 @@ from helsinki_gdpr.models import SerializableMixin
 from parking_permits.mixins import TimestampedModelMixin
 
 from ..exceptions import OrderCreationFailed
-from ..utils import diff_months_ceil, get_end_time
+from ..utils import diff_months_ceil
 from .customer import Customer
 from .parking_permit import (
     ContractType,
@@ -102,9 +102,7 @@ class OrderManager(SerializableMixin.SerializableManager):
                     )
                     start_date, end_date = date_range
                     if permit.is_open_ended:
-                        end_date = timezone.localdate(
-                            get_end_time(permit.start_time, permit.months_used)
-                        )
+                        end_date = timezone.localdate(permit.current_period_end_time)
                     OrderItem.objects.create(
                         order=order,
                         product=product,

--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.db import models, transaction
+from django.utils import timezone
 from django.utils import timezone as tz
 from django.utils.translation import gettext_lazy as _
 from helsinki_gdpr.models import SerializableMixin
@@ -8,7 +9,7 @@ from helsinki_gdpr.models import SerializableMixin
 from parking_permits.mixins import TimestampedModelMixin
 
 from ..exceptions import OrderCreationFailed
-from ..utils import diff_months_ceil
+from ..utils import diff_months_ceil, get_end_time
 from .customer import Customer
 from .parking_permit import (
     ContractType,
@@ -100,6 +101,10 @@ class OrderManager(SerializableMixin.SerializableManager):
                         permit.vehicle.is_low_emission, permit.is_secondary_vehicle
                     )
                     start_date, end_date = date_range
+                    if permit.is_open_ended:
+                        end_date = timezone.localdate(
+                            get_end_time(permit.start_time, permit.months_used)
+                        )
                     OrderItem.objects.create(
                         order=order,
                         product=product,

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -213,13 +213,13 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
     @property
     def latest_order(self):
-        """Get latest order for the permit
+        """Get the latest order for the permit
 
         Multiple orders can be created for the same permit
         when, for example, the vehicle or the address of
         the permit is changed.
         """
-        return self.orders.latest("id") if self.orders.exists() else []
+        return self.orders.latest("id") if self.orders.exists() else None
 
     @property
     def talpa_order_id(self):

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -478,16 +478,16 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
     def get_unused_order_items(self):
         unused_start_date = timezone.localdate(self.next_period_start_time)
-        if self.is_fixed_period:
-            order_items = self.latest_order_items.filter(
-                end_date__gte=unused_start_date
-            ).order_by("start_date")
-        else:
+        if not self.is_fixed_period:
             order_items = self.latest_order_items
             return [
                 [item, item.quantity, (item.start_date, item.end_date)]
                 for item in order_items
             ]
+
+        order_items = self.latest_order_items.filter(
+            end_date__gte=unused_start_date
+        ).order_by("start_date")
 
         if len(order_items) == 0:
             return []

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -239,6 +239,10 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         return self.order_items.filter(order=self.latest_order)
 
     @property
+    def latest_order_item(self):
+        return self.latest_order_items.first() or None
+
+    @property
     def permit_prices(self):
         if self.is_fixed_period:
             end_time = self.end_time

--- a/parking_permits/templates/emails/_permit_info.html
+++ b/parking_permits/templates/emails/_permit_info.html
@@ -7,7 +7,9 @@
     {% translate "Area" %}: {{ permit.parking_zone.name }} <br>
     {% translate "Vehicle" %}: {{ permit.vehicle }} <br>
     {{ permit.get_contract_type_display }} <br>
-    {% if permit.contract_type == "FIXED_PERIOD" %}
+    {% if permit.latest_order_item %}
+        {% translate "Validity period" %}: {{ permit.latest_order_item.start_time|date:"j.n.Y, H:i" }} – {{ permit.latest_order_item.end_time|date:"j.n.Y, H:i" }}
+    {% elif permit.contract_type == "FIXED_PERIOD" %}
         {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
     {% else %}
         {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} –

--- a/parking_permits/templates/emails/_permit_info.html
+++ b/parking_permits/templates/emails/_permit_info.html
@@ -7,11 +7,5 @@
     {% translate "Area" %}: {{ permit.parking_zone.name }} <br>
     {% translate "Vehicle" %}: {{ permit.vehicle }} <br>
     {{ permit.get_contract_type_display }} <br>
-    {% if permit.latest_order_item %}
-        {% translate "Validity period" %}: {{ permit.latest_order_item.start_time|date:"j.n.Y, H:i" }} – {{ permit.latest_order_item.end_time|date:"j.n.Y, H:i" }}
-    {% elif permit.contract_type == "FIXED_PERIOD" %}
-        {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
-    {% else %}
-        {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} –
-    {% endif %}
+    {% translate "Validity period" %}: {{ permit.latest_order_item.start_time|date:"j.n.Y, H:i" }} – {{ permit.latest_order_item.end_time|date:"j.n.Y, H:i" }}
 </p>

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -367,6 +367,7 @@ class ParkingZoneTestCase(TestCase):
         with self.assertRaises(ProductCatalogError):
             permit.get_products_with_quantities()
 
+    @freeze_time("2021-01-01")
     def test_get_unused_order_items_for_open_ended_permit(self):
         product_detail_list = [
             [(date(2021, 1, 1), date(2021, 6, 30)), Decimal("30")],
@@ -384,11 +385,14 @@ class ParkingZoneTestCase(TestCase):
         permit.refresh_from_db()
         permit.status = ParkingPermitStatus.VALID
         permit.save()
-        unused_items = permit.get_unused_order_items()
 
-        self.assertEqual(unused_items[0][0].unit_price, Decimal("30.00"))
-        self.assertEqual(unused_items[0][1], 1)
-        self.assertEqual(unused_items[0][2], (date(2021, 1, 1), None))
+        unused_items = permit.get_unused_order_items()
+        unused_item, quantity, (start_date, end_date) = unused_items[0]
+
+        self.assertEqual(unused_item.unit_price, Decimal("30.00"))
+        self.assertEqual(quantity, 1)
+        self.assertEqual(start_date, date(2021, 1, 1))
+        self.assertEqual(end_date, date(2021, 1, 31))
 
     def test_get_unused_order_items_return_unused_items(self):
         product_detail_list = [

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -133,7 +133,7 @@ class ParkingZoneTestCase(TestCase):
         )
         self.assertEqual(open_ended_permit_started_two_years_ago.months_left, None)
 
-    @freeze_time(timezone.make_aware(datetime(CURRENT_YEAR, 1, 20)))
+    @freeze_time(timezone.make_aware(datetime(2022, 1, 20)))
     def test_should_return_correct_end_time_of_current_time(self):
         start_time = timezone.make_aware(datetime(2021, 11, 15))
         end_time = get_end_time(start_time, 6)
@@ -145,7 +145,7 @@ class ParkingZoneTestCase(TestCase):
         )
         self.assertEqual(
             permit.current_period_end_time,
-            timezone.make_aware(datetime(CURRENT_YEAR, 2, 14, 23, 59, 59, 999999)),
+            timezone.make_aware(datetime(2022, 2, 14, 23, 59, 59, 999999)),
         )
 
         start_time = timezone.make_aware(datetime(2021, 11, 20))
@@ -158,7 +158,7 @@ class ParkingZoneTestCase(TestCase):
         )
         self.assertEqual(
             permit.current_period_end_time,
-            timezone.make_aware(datetime(CURRENT_YEAR, 2, 19, 23, 59, 59, 999999)),
+            timezone.make_aware(datetime(2022, 2, 19, 23, 59, 59, 999999)),
         )
 
     @freeze_time(timezone.make_aware(datetime(2021, 11, 20, 12, 10, 50)))

--- a/parking_permits/tests/test_utils.py
+++ b/parking_permits/tests/test_utils.py
@@ -24,6 +24,7 @@ class DiffMonthsFloorTestCase(TestCase):
         self.assertEqual(diff_months_floor(date(2021, 10, 1), date(2021, 10, 15)), 0)
         self.assertEqual(diff_months_floor(date(2021, 10, 15), date(2021, 10, 1)), 0)
         self.assertEqual(diff_months_floor(date(2021, 12, 1), date(2021, 10, 1)), 0)
+        self.assertEqual(diff_months_floor(date(2021, 1, 1), date(2021, 1, 1)), 0)
 
 
 class DiffMonthsCeilTestCase(TestCase):
@@ -35,6 +36,7 @@ class DiffMonthsCeilTestCase(TestCase):
         self.assertEqual(diff_months_ceil(date(2021, 10, 1), date(2021, 10, 15)), 1)
         self.assertEqual(diff_months_ceil(date(2021, 10, 15), date(2021, 10, 1)), 0)
         self.assertEqual(diff_months_ceil(date(2021, 12, 1), date(2021, 10, 1)), 0)
+        self.assertEqual(diff_months_ceil(date(2021, 1, 1), date(2021, 1, 1)), 1)
 
 
 class FindNextDateTestCase(TestCase):


### PR DESCRIPTION
## Description

Add end time for open-ended permits' order items. Show current period end time for open-ended permit exports (CSV, PDF) and emails.

## Context

[PV-519](https://helsinkisolutionoffice.atlassian.net/browse/PV-519)

## How Has This Been Tested?

Mostly manually. Some unit tests.

## Manual Testing Instructions for Reviewers
Use an open-ended permit.

Checklist:
- With an open-ended permit:
  - PDF export shows the current period end time
  - CSV export shows the current period end time
- Creating an open-ended permit creates an order item with the current period end time
- Any emails with permit info show the order item's end time

## Screenshots 

<!-- Add screenshots if appropriate -->


[PV-519]: https://helsinkisolutionoffice.atlassian.net/browse/PV-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ