### PR TITLE
Fix: Round VAT percentage to an integer in Talpa integration

### DIFF
--- a/parking_permits/talpa/order.py
+++ b/parking_permits/talpa/order.py
@@ -52,7 +52,7 @@ class TalpaOrderManager:
             "priceNet": cls.round_up(float(order_item.payment_unit_price_net)),
             "priceVat": cls.round_up(float(order_item.payment_unit_price_vat)),
             "priceGross": cls.round_up(float(order_item.payment_unit_price)),
-            "vatPercentage": cls.round_up(float(order_item.vat_percentage)),
+            "vatPercentage": cls.round_int(float(order_item.vat_percentage)),
             "rowPriceNet": cls.round_up(float(order_item.total_payment_price_net)),
             "rowPriceVat": cls.round_up(float(order_item.total_payment_price_vat)),
             "rowPriceTotal": cls.round_up(float(order_item.total_payment_price)),
@@ -166,6 +166,10 @@ class TalpaOrderManager:
             "customer": customer,
             "items": items,
         }
+
+    @classmethod
+    def round_int(cls, v):
+        return "{:0.0f}".format(np.round(v))
 
     @classmethod
     def round_up(cls, v):

--- a/parking_permits/tests/services/test_talpa.py
+++ b/parking_permits/tests/services/test_talpa.py
@@ -1,0 +1,16 @@
+import pytest
+
+from parking_permits.talpa.order import TalpaOrderManager
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (1.0, "1"),
+        (1.01, "1"),
+        (1.499999, "1"),
+        (1.5, "2"),
+    ],
+)
+def test_round_int(value, expected):
+    assert TalpaOrderManager.round_int(value) == expected


### PR DESCRIPTION
## Description

Round VAT percentage to the closest integer in Talpa integration.

## Context

Talpa doesn't like decimals in VAT percentages.

## How Has This Been Tested?

A very minimal unit test.

## Manual Testing Instructions for Reviewers

Don't really have any instructions. Difficult to test locally.

