### PR TITLE
PV-519: Remove order item dates from permit info email, revert to permit dates

### DIFF
--- a/parking_permits/templates/emails/_permit_info.html
+++ b/parking_permits/templates/emails/_permit_info.html
@@ -7,5 +7,11 @@
     {% translate "Area" %}: {{ permit.parking_zone.name }} <br>
     {% translate "Vehicle" %}: {{ permit.vehicle }} <br>
     {{ permit.get_contract_type_display }} <br>
-    {% translate "Validity period" %}: {{ permit.latest_order_item.start_time|date:"j.n.Y, H:i" }} – {{ permit.latest_order_item.end_time|date:"j.n.Y, H:i" }}
+    {% if permit.latest_order_item %}
+        {% translate "Validity period" %}: {{ permit.latest_order_item.start_time|date:"j.n.Y, H:i" }} – {{ permit.latest_order_item.end_time|date:"j.n.Y, H:i" }}
+    {% elif permit.contract_type == "FIXED_PERIOD" %}
+        {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
+    {% else %}
+        {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} –
+    {% endif %}
 </p>

--- a/parking_permits/templates/emails/_permit_info.html
+++ b/parking_permits/templates/emails/_permit_info.html
@@ -7,9 +7,7 @@
     {% translate "Area" %}: {{ permit.parking_zone.name }} <br>
     {% translate "Vehicle" %}: {{ permit.vehicle }} <br>
     {{ permit.get_contract_type_display }} <br>
-    {% if permit.latest_order_item %}
-        {% translate "Validity period" %}: {{ permit.latest_order_item.start_time|date:"j.n.Y, H:i" }} – {{ permit.latest_order_item.end_time|date:"j.n.Y, H:i" }}
-    {% elif permit.contract_type == "FIXED_PERIOD" %}
+    {% if permit.contract_type == "FIXED_PERIOD" %}
         {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
     {% else %}
         {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} –


### PR DESCRIPTION
## Description

Remove order item dates from permit info email, revert to permit dates.

## Context

Didn't work since the email is sent before the order items are created. Reverting to old implementation.

[PV-519](https://helsinkisolutionoffice.atlassian.net/browse/PV-519)


[PV-519]: https://helsinkisolutionoffice.atlassian.net/browse/PV-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ