### PR TITLE
PV-519: Fix typo in permit info email template

### DIFF
--- a/parking_permits/templates/emails/_permit_info.html
+++ b/parking_permits/templates/emails/_permit_info.html
@@ -7,5 +7,5 @@
     {% translate "Area" %}: {{ permit.parking_zone.name }} <br>
     {% translate "Vehicle" %}: {{ permit.vehicle }} <br>
     {{ permit.get_contract_type_display }} <br>
-    {% translate "Validity period" %}: {{ permit.latest_order_item.start_time|date:"j.n.Y, H:i" }} – {{ permit.latest_order_item.end_time|date:"j.n.Y, H:i" }}
+    {% translate "Validity period" %}: {{ permit.latest_order_item.start_date|date:"j.n.Y, H:i" }} – {{ permit.latest_order_item.end_date|date:"j.n.Y, H:i" }}
 </p>


### PR DESCRIPTION
## Description

Fix typo in permit info email template

## Context

Wrong attribute name equals missing values.

[PV-519](https://helsinkisolutionoffice.atlassian.net/browse/PV-519)


[PV-519]: https://helsinkisolutionoffice.atlassian.net/browse/PV-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ