### PR TITLE
Cancel linked Talpa order and subscription

### DIFF
--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -19,7 +19,7 @@ db_logger = logging.getLogger("db")
 def automatic_expiration_of_permits():
     logger.info("Automatically ending permits started...")
     ending_permits = ParkingPermit.objects.filter(
-        end_time__lt=tz.localdate(tz.now()), status=ParkingPermitStatus.VALID
+        end_time__lt=tz.now(), status=ParkingPermitStatus.VALID
     )
     for permit in ending_permits:
         permit.status = ParkingPermitStatus.CLOSED
@@ -35,7 +35,7 @@ def automatic_expiration_of_permits():
 def automatic_expiration_remind_notification_of_permits():
     logger.info("Automatically sending remind notifications for permits started...")
     count = 0
-    now = tz.localdate(tz.now())
+    now = tz.now()
     expiring_permits = ParkingPermit.objects.filter(
         end_time__lt=now + relativedelta(weeks=1), status=ParkingPermitStatus.VALID
     )

--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -398,6 +398,14 @@ class CustomerPermit:
                     cancel_reason=subscription_cancel_reason,
                     cancel_from_talpa=cancel_from_talpa,
                 )
+            else:
+                # Cancel fixed period permit order when this is the last valid permit in that order
+                if (
+                    not permit.order.permits.filter(status=[VALID])
+                    .exclude(permit=permit.id)
+                    .exists()
+                ):
+                    permit.order.cancel(cancel_from_talpa=cancel_from_talpa)
 
             active_temporary_vehicle = permit.active_temporary_vehicle
             if active_temporary_vehicle:

--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -138,7 +138,7 @@ class CustomerPermit:
         permits = []
         # Delete all the draft permits if it wasn't created today
         draft_permits = self.customer_permit_query.filter(
-            status=DRAFT, start_time__lt=tz.localdate(tz.now())
+            status=DRAFT, start_time__lt=tz.now()
         ).all()
         for permit in draft_permits:
             permit.order_items.all().delete()
@@ -150,13 +150,13 @@ class CustomerPermit:
             )
             vehicle = permit.vehicle
             # Update vehicle detail from traficom if it wasn't updated today
-            if permit.vehicle.updated_from_traficom_on < tz.localdate(tz.now()):
+            if permit.vehicle.updated_from_traficom_on < tz.now().date():
                 self.customer.fetch_vehicle_detail(vehicle.registration_number)
 
             user_of_vehicle = self.customer.is_user_of_vehicle(vehicle)
             if not user_of_vehicle:
                 permit.vehicle_changed = True
-                permit.vehicle_changed_date = tz.localdate(tz.now())
+                permit.vehicle_changed_date = tz.now().date()
                 permit.save()
             products = []
             for product_with_qty in permit.get_products_with_quantities():

--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -343,7 +343,15 @@ class CustomerPermit:
 
         return self._update_fields_to_all_draft(fields_to_update)
 
-    def end(self, permit_ids, end_type, iban=None, user=None):
+    def end(
+        self,
+        permit_ids,
+        end_type,
+        iban=None,
+        user=None,
+        subscription_cancel_reason=SubscriptionCancelReason.USER_CANCELLED,
+        cancel_from_talpa=True,
+    ):
         permits = self.customer_permit_query.filter(id__in=permit_ids).order_by(
             "primary_vehicle"
         )
@@ -383,12 +391,12 @@ class CustomerPermit:
 
         for permit in permits:
             if permit.contract_type == ContractType.OPEN_ENDED:
-                # Cancel Talpa subscription
                 subscription = Subscription.objects.get(
                     order_items__permit__pk=permit.pk
                 )
                 subscription.cancel(
-                    cancel_reason=SubscriptionCancelReason.USER_CANCELLED
+                    cancel_reason=subscription_cancel_reason,
+                    cancel_from_talpa=cancel_from_talpa,
                 )
 
             active_temporary_vehicle = permit.active_temporary_vehicle

--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -25,10 +25,16 @@ from .models import (
     OrderItem,
     ParkingPermit,
     Refund,
+    Subscription,
     TemporaryVehicle,
     Vehicle,
 )
-from .models.order import OrderPaymentType, OrderStatus, OrderType
+from .models.order import (
+    OrderPaymentType,
+    OrderStatus,
+    OrderType,
+    SubscriptionCancelReason,
+)
 from .models.parking_permit import (
     ContractType,
     ParkingPermitEventFactory,
@@ -376,6 +382,15 @@ class CustomerPermit:
                     )
 
         for permit in permits:
+            if permit.contract_type == ContractType.OPEN_ENDED:
+                # Cancel Talpa subscription
+                subscription = Subscription.objects.get(
+                    order_items__permit__pk=permit.pk
+                )
+                subscription.cancel(
+                    cancel_reason=SubscriptionCancelReason.USER_CANCELLED
+                )
+
             active_temporary_vehicle = permit.active_temporary_vehicle
             if active_temporary_vehicle:
                 active_temporary_vehicle.is_active = False

--- a/parking_permits/exceptions.py
+++ b/parking_permits/exceptions.py
@@ -50,6 +50,14 @@ class OrderValidationError(ParkingPermitBaseException):
     pass
 
 
+class OrderCancelError(ParkingPermitBaseException):
+    pass
+
+
+class SubscriptionCancelError(ParkingPermitBaseException):
+    pass
+
+
 class SetTalpaFlowStepsError(ParkingPermitBaseException):
     pass
 

--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -31,6 +31,34 @@ from .refund import Refund
 logger = logging.getLogger("db")
 
 
+class OrderValidator:
+    @staticmethod
+    def validate_order(order_id, user_id):
+        headers = {
+            "api-key": settings.TALPA_API_KEY,
+            "namespace": settings.NAMESPACE,
+            "Content-Type": "application/json",
+        }
+        response = requests.get(
+            f"{settings.TALPA_ORDER_EXPERIENCE_API}/admin/{order_id}",
+            headers=headers,
+        )
+        if response.status_code == 200:
+            order = response.json()
+            if order["user"] != str(user_id):
+                logger.error(
+                    f"Talpa order user id {order['userId']} does not match with user id {user_id}"
+                )
+                raise OrderValidationError(
+                    f"Talpa order user id {order['userId']} does not match with user id {user_id}"
+                )
+            logger.info("Talpa order is valid")
+            return order
+        else:
+            logger.error("Talpa order is not valid")
+            raise OrderValidationError("Talpa order is not valid")
+
+
 class OrderPaymentType(models.TextChoices):
     ONLINE_PAYMENT = "ONLINE_PAYMENT", _("Online payment")
     CASHIER_PAYMENT = "CASHIER_PAYMENT", _("Cashier payment")
@@ -242,42 +270,6 @@ class OrderManager(SerializableMixin.SerializableManager):
 
         return new_order
 
-    def _cancel_talpa_order(self, talpa_order_id):
-        headers = {
-            "api-key": settings.TALPA_API_KEY,
-            "namespace": settings.NAMESPACE,
-            "Content-Type": "application/json",
-        }
-        response = requests.post(
-            f"{settings.TALPA_ORDER_EXPERIENCE_API}/{talpa_order_id}/cancel",
-            headers=headers,
-        )
-        if response.status_code == 200:
-            logger.info(f"Talpa order cancelling successful: {talpa_order_id}")
-            return True
-        else:
-            logger.error("Talpa order cancelling failed")
-            logger.error(
-                "Talpa order cancelling failed."
-                f"Error: {response.status_code} {response.reason}. "
-                f"Detail: {response.text}"
-            )
-            raise OrderCancelError(
-                "Talpa order cancelling failed."
-                f"Error: {response.status_code} {response.reason}."
-            )
-
-    @transaction.atomic
-    def cancel(self, talpa_order_id):
-        logger.info(f"Cancelling order: {talpa_order_id}")
-        order = Order.objects.get(talpa_order_id=talpa_order_id)
-        # Cancel order from Talpa as well
-        if self._cancel_talpa_order(talpa_order_id):
-            order.status = OrderStatus.CANCELLED
-            order.save()
-            return True
-        return False
-
 
 class Order(SerializableMixin, TimestampedModelMixin, UserStampedModelMixin):
     talpa_order_id = models.UUIDField(
@@ -377,6 +369,54 @@ class Order(SerializableMixin, TimestampedModelMixin, UserStampedModelMixin):
     def total_payment_price_vat(self):
         return sum([item.total_payment_price_vat for item in self.order_items.all()])
 
+    def _cancel_talpa_order(self, talpa_order_id):
+        headers = {
+            "api-key": settings.TALPA_API_KEY,
+            "namespace": settings.NAMESPACE,
+            "Content-Type": "application/json",
+        }
+        response = requests.post(
+            f"{settings.TALPA_ORDER_EXPERIENCE_API}/{talpa_order_id}/cancel",
+            headers=headers,
+        )
+        if response.status_code == 200:
+            logger.info(f"Talpa order cancelling successful: {talpa_order_id}")
+            return True
+        else:
+            logger.error("Talpa order cancelling failed")
+            logger.error(
+                "Talpa order cancelling failed."
+                f"Error: {response.status_code} {response.reason}. "
+                f"Detail: {response.text}"
+            )
+            raise OrderCancelError(
+                "Talpa order cancelling failed."
+                f"Error: {response.status_code} {response.reason}."
+            )
+
+    @transaction.atomic
+    def cancel(self, talpa_order_id=None, cancel_from_talpa=True):
+        logger.info(f"Cancelling order: {talpa_order_id}")
+        order = Order.objects.get(talpa_order_id=talpa_order_id)
+
+        try:
+            OrderValidator.validate_order(talpa_order_id, order.customer.user.uuid)
+        except OrderValidationError as e:
+            logger.error(f"Order validation failed. Error = {e}")
+            return False
+
+        # Try to cancel order from Talpa as well
+        if cancel_from_talpa:
+            try:
+                self._cancel_talpa_order(talpa_order_id)
+            except OrderCancelError:
+                logger.warning(
+                    "Talpa order cancelling failed. Continuing the cancel process.."
+                )
+        order.status = OrderStatus.CANCELLED
+        order.save()
+        return True
+
 
 class SubscriptionStatus(models.TextChoices):
     CONFIRMED = "CONFIRMED", _("Confirmed")
@@ -412,31 +452,6 @@ class Subscription(SerializableMixin, TimestampedModelMixin, UserStampedModelMix
     def __str__(self):
         return f"Subscription #{self.talpa_subscription_id}"
 
-    def _validate_order(self, order_id, user_id):
-        headers = {
-            "api-key": settings.TALPA_API_KEY,
-            "namespace": settings.NAMESPACE,
-            "Content-Type": "application/json",
-        }
-        response = requests.get(
-            f"{settings.TALPA_ORDER_EXPERIENCE_API}/admin/{order_id}",
-            headers=headers,
-        )
-        if response.status_code == 200:
-            order = response.json()
-            if order["user"] != str(user_id):
-                logger.error(
-                    f"Talpa order user id {order['userId']} does not match with user id {user_id}"
-                )
-                raise OrderValidationError(
-                    f"Talpa order user id {order['userId']} does not match with user id {user_id}"
-                )
-            logger.info("Talpa order is valid")
-            return order
-        else:
-            logger.error("Talpa order is not valid")
-            raise OrderValidationError("Talpa order is not valid")
-
     def _cancel_talpa_subcription(self):
         headers = {
             "api-key": settings.TALPA_API_KEY,
@@ -465,7 +480,7 @@ class Subscription(SerializableMixin, TimestampedModelMixin, UserStampedModelMix
             )
 
     @transaction.atomic
-    def cancel(self, cancel_reason):
+    def cancel(self, cancel_reason, cancel_from_talpa=True):
         logger.info(f"Cancelling subscription: {self.talpa_subscription_id}")
 
         order_item = self.order_items.first()
@@ -474,16 +489,23 @@ class Subscription(SerializableMixin, TimestampedModelMixin, UserStampedModelMix
         permit = order_item.permit
 
         try:
-            self._validate_order(talpa_order_id, permit.customer.user.uuid)
+            OrderValidator.validate_order(talpa_order_id, permit.customer.user.uuid)
         except OrderValidationError as e:
             logger.error(f"Order validation failed. Error = {e}")
             return False
 
-        # Cancel subscription from Talpa as well
-        if self._cancel_talpa_subcription():
-            self.status = SubscriptionStatus.CANCELLED
-            self.cancel_reason = cancel_reason
-            self.save()
+        # Try to cancel subscription from Talpa as well
+        if cancel_from_talpa:
+            try:
+                self._cancel_talpa_subcription()
+            except SubscriptionCancelError:
+                logger.warning(
+                    "Talpa subscription cancelling failed. Continuing the cancel process.."
+                )
+
+        self.status = SubscriptionStatus.CANCELLED
+        self.cancel_reason = cancel_reason
+        self.save()
 
         remaining_valid_order_subscriptions = Subscription.objects.filter(
             order_items__order__talpa_order_id__exact=talpa_order_id,
@@ -491,7 +513,9 @@ class Subscription(SerializableMixin, TimestampedModelMixin, UserStampedModelMix
         )
         # Mark the order as cancelled if it has no active subscriptions left
         if not remaining_valid_order_subscriptions.exists():
-            order.cancel()
+            order.cancel(
+                talpa_order_id=talpa_order_id, cancel_from_talpa=cancel_from_talpa
+            )
 
         # Create a refund for a remaining full month period, if it was charged already
         if permit.end_time and permit.end_time - relativedelta(months=1) > tz.now():

--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -18,6 +18,7 @@ from parking_permits.models.order import (
     Order,
     OrderPaymentType,
     OrderStatus,
+    OrderValidator,
     Subscription,
     SubscriptionStatus,
 )
@@ -115,7 +116,7 @@ class OrderViewTestCase(APITestCase):
         self.assertEqual(response.status_code, 400)
 
     @override_settings(DEBUG=True)
-    @patch("parking_permits.views.validate_order")
+    @patch.object(OrderValidator, "validate_order")
     def test_subscription_renewal(self, mock_validate_order):
         talpa_existing_order_id = "d86ca61d-97e9-410a-a1e3-4894873b1b35"
         talpa_existing_order_item_id = "7c779368-7e5f-42dc-9ffe-554915cb5540"
@@ -222,7 +223,7 @@ class SubscriptionViewTestCase(APITestCase):
         self.assertEqual(response.status_code, 400)
 
     @override_settings(DEBUG=True)
-    @patch("parking_permits.views.validate_order")
+    @patch.object(OrderValidator, "validate_order")
     def test_subscription_creation(self, mock_validate_order):
         talpa_order_id = "d86ca61d-97e9-410a-a1e3-4894873b1b35"
         talpa_subscription_id = "f769b803-0bd0-489d-aa81-b35af391f391"
@@ -274,7 +275,7 @@ class SubscriptionViewTestCase(APITestCase):
         self.assertEqual(permit_2.status, ParkingPermitStatus.VALID)
 
     @override_settings(DEBUG=True)
-    @patch("parking_permits.views.validate_order")
+    @patch.object(OrderValidator, "validate_order")
     @freeze_time("2023-05-30")
     def test_subscription_cancellation(self, mock_validate_order):
         talpa_order_id = "d86ca61d-97e9-410a-a1e3-4894873b1b35"
@@ -336,7 +337,7 @@ class SubscriptionViewTestCase(APITestCase):
         self.assertEqual(permit.status, ParkingPermitStatus.VALID)
 
     @override_settings(DEBUG=True)
-    @patch("parking_permits.views.validate_order")
+    @patch.object(OrderValidator, "validate_order")
     @freeze_time("2023-05-30")
     def test_subscription_cancellation_with_refund(self, mock_validate_order):
         talpa_order_id = "d86ca61d-97e9-410a-a1e3-4894873b1b35"

--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timezone as dt_tz
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -6,6 +7,7 @@ import requests_mock
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
+from django.utils import timezone as tz
 from freezegun import freeze_time
 from helusers.settings import api_token_auth_settings
 from jose import jwt
@@ -137,8 +139,10 @@ class OrderViewTestCase(APITestCase):
             talpa_order_id=talpa_existing_order_id,
             customer=customer,
             status=OrderStatus.CONFIRMED,
-            paid_time=datetime.datetime.strptime(
-                "2023-06-01T15:46:05.000Z", "%Y-%m-%dT%H:%M:%S.%fZ"
+            paid_time=tz.make_aware(
+                datetime.datetime.strptime(
+                    "2023-06-01T15:46:05.000Z", "%Y-%m-%dT%H:%M:%S.%fZ"
+                )
             ),
         )
         order.permits.add(permit)
@@ -422,7 +426,7 @@ class ParkingPermitsGDPRAPIViewTestCase(APITestCase):
         ParkingPermitFactory(
             customer=customer,
             status=ParkingPermitStatus.CLOSED,
-            end_time=datetime.datetime(2020, 2, 1),
+            end_time=tz.localtime(datetime.datetime(2020, 2, 1, tzinfo=dt_tz.utc)),
         )
         return customer
 
@@ -530,7 +534,7 @@ class ParkingPermitsGDPRAPIViewTestCase(APITestCase):
             ParkingPermitFactory(
                 customer=customer,
                 status=ParkingPermitStatus.CLOSED,
-                end_time=datetime.datetime(2020, 2, 1),
+                end_time=tz.localtime(datetime.datetime(2020, 2, 1, tzinfo=dt_tz.utc)),
             )
 
         with freeze_time(datetime.datetime(2022, 1, 15)):
@@ -552,7 +556,7 @@ class ParkingPermitsGDPRAPIViewTestCase(APITestCase):
             ParkingPermitFactory(
                 customer=customer,
                 status=ParkingPermitStatus.CLOSED,
-                end_time=datetime.datetime(2020, 2, 1),
+                end_time=tz.localtime(datetime.datetime(2020, 2, 1, tzinfo=dt_tz.utc)),
             )
 
         with freeze_time(datetime.datetime(2022, 3, 1)):

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -415,6 +415,12 @@ class OrderView(APIView):
                 logger.error(f"Order validation failed. Error = {e}")
                 return Response({"message": str(e)}, status=400)
 
+            paid_time = tz.make_aware(
+                datetime.datetime.strptime(
+                    validated_order_data.get("lastValidPurchaseDateTime"),
+                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                )
+            )
             order = Order.objects.create(
                 talpa_order_id=validated_order_data.get("orderId"),
                 talpa_checkout_url=validated_order_data.get("checkoutUrl"),
@@ -425,10 +431,7 @@ class OrderView(APIView):
                 payment_type=OrderPaymentType.ONLINE_PAYMENT,
                 customer=permit.customer,
                 status=OrderStatus.CONFIRMED,
-                paid_time=datetime.datetime.strptime(
-                    validated_order_data.get("lastValidPurchaseDateTime"),
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
+                paid_time=paid_time,
                 address_text=str(permit.address),
                 parking_zone_name=permit.parking_zone.name,
                 vehicles=[permit.vehicle.registration_number],
@@ -446,8 +449,10 @@ class OrderView(APIView):
                 talpa_product_id=validated_order_item_data.get("productId")
             )
 
-            start_time = datetime.datetime.strptime(
-                validated_order_item_data.get("startDate"), "%Y-%m-%dT%H:%M:%S"
+            start_time = tz.make_aware(
+                datetime.datetime.strptime(
+                    validated_order_item_data.get("startDate"), "%Y-%m-%dT%H:%M:%S"
+                )
             )
             end_time = get_end_time(start_time, 1)
 

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -211,7 +211,9 @@ class TalpaResolveRightOfPurchase(APIView):
         logger.info(
             f"Data received for resolve right of purchase = {json.dumps(request.data, default=str)}"
         )
-        meta = request.data.get("orderItem").get("meta")
+        order_item_data = request.data.get("orderItem")
+        order_item_id = order_item_data.get("orderItemId")
+        meta = order_item_data.get("meta")
         permit_id = get_meta_value(meta, "permitId")
         user_id = request.data.get("userId")
 
@@ -224,8 +226,13 @@ class TalpaResolveRightOfPurchase(APIView):
             has_valid_driving_licence = customer.has_valid_driving_licence_for_vehicle(
                 vehicle
             )
+            order_item = OrderItem.objects.get(talpa_order_item_id=order_item_id)
+            is_valid_subscription = (
+                order_item.subscription.status == SubscriptionStatus.CONFIRMED
+            )
             right_of_purchase = (
-                is_user_of_vehicle
+                is_valid_subscription
+                and is_user_of_vehicle
                 and customer.driving_licence.active
                 and has_valid_driving_licence
                 and not vehicle.is_due_for_inspection()


### PR DESCRIPTION
## Description

During permit ending process, cancel also linked Talpa order and subscription.

## Context

[PV-592](https://helsinkisolutionoffice.atlassian.net/browse/PV-592)
[PV-593](https://helsinkisolutionoffice.atlassian.net/browse/PV-593)

## How Has This Been Tested?

Manually by ending the permit from the webshop UI and using mocked JUnit-tests.


[PV-592]: https://helsinkisolutionoffice.atlassian.net/browse/PV-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PV-593]: https://helsinkisolutionoffice.atlassian.net/browse/PV-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ