### PR TITLE
Make update_or_create_address null-safe

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -331,11 +331,11 @@ def update_or_create_address(address_info):
     address_obj = Address.objects.update_or_create(
         street_name=address_info["street_name"],
         street_name_sv=address_info["street_name_sv"]
-        if address_info["street_name_sv"]
+        if address_info.get("street_name_sv")
         else "",
         street_number=address_info["street_number"],
-        city=address_info["city"] if address_info["city"] else "",
-        city_sv=address_info["city_sv"] if address_info["city_sv"] else "",
+        city=address_info["city"] if address_info.get("city") else "",
+        city_sv=address_info["city_sv"] if address_info.get("city_sv") else "",
         postal_code=address_info["postal_code"],
         location=location,
     )

--- a/parking_permits/exporters.py
+++ b/parking_permits/exporters.py
@@ -199,9 +199,9 @@ class DataExporter:
             "metadata": {
                 "copyright": {
                     "© " + _("City of Helsinki") + ", ",
-                    +_("Personal data - Digital and population data services agency")
+                    _("Personal data - Digital and population data services agency")
                     + ", ",
-                    +_("Vehicle and driving licence data - Traficom")
+                    _("Vehicle and driving licence data - Traficom")
                     + " "
                     + str(CURRENT_YEAR),
                 }


### PR DESCRIPTION
This is causing a KeyError, e.g.

```
File "/app/parking_permits/admin_resolvers.py", line 334, in update_or_create_address if address_info["street_name_sv"]
KeyError: 'street_name_sv'
ERROR:ariadne:'street_name_sv'
```

This PR fixes this.