### PR TITLE
Fix open-ended permit deletion to work with latest Talpa-integration requests

### DIFF
--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urljoin
 
 import requests
 from dateutil.relativedelta import relativedelta
@@ -39,7 +40,7 @@ class OrderValidator:
             "Content-Type": "application/json",
         }
         response = requests.get(
-            f"{settings.TALPA_ORDER_EXPERIENCE_API}/admin/{order_id}",
+            urljoin(settings.TALPA_ORDER_EXPERIENCE_API, f"admin/{order_id}"),
             headers=headers,
         )
         if response.status_code == 200:
@@ -369,10 +370,13 @@ class Order(SerializableMixin, TimestampedModelMixin, UserStampedModelMixin):
         headers = {
             "api-key": settings.TALPA_API_KEY,
             "namespace": settings.NAMESPACE,
+            "user": str(self.customer.user.uuid),
             "Content-Type": "application/json",
         }
         response = requests.post(
-            f"{settings.TALPA_ORDER_EXPERIENCE_API}/{self.talpa_order_id}/cancel",
+            urljoin(
+                settings.TALPA_ORDER_EXPERIENCE_API, f"{self.talpa_order_id}/cancel"
+            ),
             headers=headers,
         )
         if response.status_code == 200:
@@ -452,7 +456,10 @@ class Subscription(SerializableMixin, TimestampedModelMixin, UserStampedModelMix
             "Content-Type": "application/json",
         }
         response = requests.post(
-            f"{settings.TALPA_ORDER_EXPERIENCE_API}/subcription/{self.talpa_subscription_id}/cancel",
+            urljoin(
+                settings.TALPA_ORDER_EXPERIENCE_API,
+                f"subcription/{self.talpa_subscription_id}/cancel",
+            ),
             headers=headers,
         )
         if response.status_code == 200:

--- a/parking_permits/models/product.py
+++ b/parking_permits/models/product.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from decimal import Decimal
+from urllib.parse import urljoin
 
 import requests
 from dateutil.relativedelta import relativedelta
@@ -180,7 +181,10 @@ class Product(TimestampedModelMixin, UserStampedModelMixin):
             "Content-Type": "application/json",
         }
         response = requests.get(
-            f"{settings.TALPA_MERCHANT_EXPERIENCE_API}/list/merchants/{settings.NAMESPACE}/",
+            urljoin(
+                settings.TALPA_MERCHANT_EXPERIENCE_API,
+                f"list/merchants/{settings.NAMESPACE}/",
+            ),
             headers=headers,
         )
         if response.status_code == 200:


### PR DESCRIPTION
## Description

Fix open-ended permit deletion to work with latest Talpa-integration requests.
Done by removing duplicate slashes and adding user-header to Talpa Admin Order-request.

## Context

[PV-617](https://helsinkisolutionoffice.atlassian.net/browse/PV-617)

## How Has This Been Tested?

Locally manually.


[PV-617]: https://helsinkisolutionoffice.atlassian.net/browse/PV-617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ