### PR TITLE
Permit-form DVV customer search should also take address apartments into account

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -267,7 +267,6 @@ def resolve_customer(obj, info, audit_msg: AuditMsg = None, **data):
             audit_msg.event_type = audit.EventType.DVV
             logger.info("Customer does not exist, searching from DVV...")
             customer = get_person_info(query_params.get("national_id_number"))
-
         if not customer:
             raise ObjectNotFound(_("Person not found"))
 

--- a/parking_permits/services/dvv.py
+++ b/parking_permits/services/dvv.py
@@ -32,7 +32,9 @@ class DvvPersonInfo(TypedDict, total=False):
     first_name: str
     last_name: str
     primary_address: Optional[DvvAddressInfo]
+    primary_address_apartment: str
     other_address: Optional[DvvAddressInfo]
+    other_address_apartment: str
     phone_number: str
     email: str
     address_security_ban: bool
@@ -68,7 +70,7 @@ def get_addresses(national_id_number):
     return primary_address, other_address
 
 
-def _extract_address_data(address) -> DvvAddressInfo:
+def _extract_address_data(address) -> Optional[DvvAddressInfo]:
     return (
         {
             "street_name": address.get("street_name"),
@@ -151,24 +153,29 @@ def get_person_info(national_id_number) -> Optional[DvvPersonInfo]:
 
     last_name = person_info["NykyinenSukunimi"]["Sukunimi"]
     first_name = person_info["NykyisetEtunimet"]["Etunimet"]
+
+    primary_address, primary_apartment = None, ""
     permanent_address = person_info["VakinainenKotimainenLahiosoite"]
+
+    if is_valid_address(permanent_address):
+        primary_address = format_address(permanent_address)
+        primary_apartment = primary_address.get("apartment", "")
+
+    other_address, other_apartment = None, ""
     temporary_address = person_info["TilapainenKotimainenLahiosoite"]
-    primary_address = (
-        format_address(permanent_address)
-        if is_valid_address(permanent_address)
-        else None
-    )
-    other_address = (
-        format_address(temporary_address)
-        if is_valid_address(temporary_address)
-        else None
-    )
+
+    if is_valid_address(temporary_address):
+        other_address = format_address(temporary_address)
+        other_apartment = other_address.get("apartment", "")
+
     return {
         "national_id_number": national_id_number,
         "first_name": first_name,
         "last_name": last_name,
         "primary_address": primary_address,
         "other_address": other_address,
+        "primary_address_apartment": primary_apartment,
+        "other_address_apartment": other_apartment,
         "phone_number": "",
         "email": "",
         "address_security_ban": False,

--- a/parking_permits/tests/services/test_dvv.py
+++ b/parking_permits/tests/services/test_dvv.py
@@ -3,9 +3,107 @@ from unittest.mock import patch
 import factory
 from django.test import TestCase
 
-from parking_permits.services.dvv import get_addresses
+from parking_permits.services.dvv import get_addresses, get_person_info
 from parking_permits.tests.factories.customer import AddressFactory, CustomerFactory
+from parking_permits.tests.factories.zone import generate_multi_polygon
 from parking_permits.utils import to_dict
+
+
+class GetPersonInfoTestCase(TestCase):
+    class MockResponse:
+        def __init__(self, *, data=None, ok=True, text=""):
+            self.data = data
+            self.ok = ok
+            self.text = text
+
+        def json(self):
+            return self.data
+
+    @patch("requests.post")
+    def test_bad_response(self, mock_post):
+        mock_post.return_value = self.MockResponse(ok=False, text="oops")
+        customer = get_person_info("12345")
+        self.assertEqual(customer, None)
+
+    @patch("parking_permits.services.dvv.get_address_details")
+    @patch("requests.post")
+    def test_get_customer_info(self, mock_post, mock_get_address_details):
+        mock_post.return_value = self.MockResponse(data=self.get_mock_info())
+        mock_get_address_details.return_value = {"location": generate_multi_polygon()}
+        customer = get_person_info("12345")
+        self.assertEqual(customer["first_name"], "Heikki")
+        self.assertEqual(customer["last_name"], "Häkkinen")
+        self.assertEqual(customer["primary_address"]["street_name"], "Käsivoide")
+        self.assertEqual(customer["primary_address"]["street_number"], "1")
+        self.assertEqual(customer["primary_address"]["postal_code"], "10001")
+        self.assertEqual(customer["primary_address"]["city"], "Helsinki")
+        self.assertEqual(customer["primary_address_apartment"], "A6")
+        self.assertEqual(customer["other_address_apartment"], "B7")
+
+    @patch("parking_permits.services.dvv.get_address_details")
+    @patch("requests.post")
+    def test_get_customer_info_apartment_not_included(
+        self, mock_post, mock_get_address_details
+    ):
+        mock_info = self.get_mock_info()
+        mock_info["Henkilo"]["VakinainenKotimainenLahiosoite"][
+            "LahiosoiteS"
+        ] = "Käsivoide 1"
+        mock_post.return_value = self.MockResponse(data=mock_info)
+        mock_get_address_details.return_value = {"location": generate_multi_polygon()}
+        customer = get_person_info("12345")
+        self.assertEqual(customer["first_name"], "Heikki")
+        self.assertEqual(customer["last_name"], "Häkkinen")
+        self.assertEqual(customer["primary_address"]["street_name"], "Käsivoide")
+        self.assertEqual(customer["primary_address"]["street_number"], "1")
+        self.assertEqual(customer["primary_address"]["postal_code"], "10001")
+        self.assertEqual(customer["primary_address"]["city"], "Helsinki")
+        self.assertEqual(customer["primary_address_apartment"], "")
+
+    @patch("parking_permits.services.dvv.get_address_details")
+    @patch("requests.post")
+    def test_get_customer_info_addresses_not_in_helsinki(
+        self, mock_post, mock_get_address_details
+    ):
+        mock_info = self.get_mock_info()
+        mock_info["Henkilo"]["VakinainenKotimainenLahiosoite"][
+            "PostitoimipaikkaS"
+        ] = "Vantaa"
+        mock_info["Henkilo"]["TilapainenKotimainenLahiosoite"][
+            "PostitoimipaikkaS"
+        ] = "Espoo"
+        mock_post.return_value = self.MockResponse(data=mock_info)
+        mock_get_address_details.return_value = {"location": generate_multi_polygon()}
+        customer = get_person_info("12345")
+        self.assertEqual(customer["first_name"], "Heikki")
+        self.assertEqual(customer["last_name"], "Häkkinen")
+        self.assertEqual(customer["primary_address"], None)
+        self.assertEqual(customer["primary_address_apartment"], "")
+        self.assertEqual(customer["other_address"], None)
+        self.assertEqual(customer["other_address_apartment"], "")
+
+    def get_mock_info(self, **kwargs):
+        return {
+            "Henkilo": {
+                "NykyinenSukunimi": {"Sukunimi": "Häkkinen"},
+                "NykyisetEtunimet": {"Etunimet": "Heikki"},
+                "VakinainenKotimainenLahiosoite": {
+                    "LahiosoiteS": "Käsivoide 1 A6",
+                    "PostitoimipaikkaS": "Helsinki",
+                    "LahiosoiteR": "Handkrem 1 A6",
+                    "PostitoimipaikkaR": "Helsingfors",
+                    "Postinumero": "10001",
+                },
+                "TilapainenKotimainenLahiosoite": {
+                    "LahiosoiteS": "Käsivoide 6 B7",
+                    "PostitoimipaikkaS": "Helsinki",
+                    "LahiosoiteR": "Handkrem 6 B7",
+                    "PostitoimipaikkaR": "Helsingfors",
+                    "Postinumero": "10001",
+                },
+            },
+            **kwargs,
+        }
 
 
 class DvvServiceTestCase(TestCase):


### PR DESCRIPTION
This change copies over apartment number information present in the DVV search, so it can be automatically inserted for example when completing the admin UI permit form when selecting primary/temporary address.

## Description

Currently the apartment number is returned from DVV along with other address details, but is dropped when returning those details to the caller. Instead we copy those details over to two apartment fields in the "customer" parent node.

If no such data is found, these fields will just be an empty string.

## Context

[PV-618](https://helsinkisolutionoffice.atlassian.net/browse/PV-618)

## How Has This Been Tested?

Tested manually using admin UI form along with unit tests.

## Manual Testing Instructions for Reviewers

In admin UI, enter one of the test addresses which have an apartment number included in DVV database. When you select the "Permanent" radio button, and the apartment is present, that value should be automatically inserted into the "Apartment" field.

## Screenshots

<!-- Add screenshots if appropriate -->


[PV-618]: https://helsinkisolutionoffice.atlassian.net/browse/PV-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ