### PR TITLE
Use customer full name in customer notification emails

### DIFF
--- a/parking_permits/templates/emails/_permit_info.html
+++ b/parking_permits/templates/emails/_permit_info.html
@@ -2,7 +2,7 @@
 <p>
     {% translate "Order info" %}: <br>
     {{ permit.get_type_display }} <br>
-    {{ permit.customer }} <br>
+    {{ permit.customer.full_name }} <br>
     {% translate "Address" %}: {{ permit.address }} <br>
     {% translate "Area" %}: {{ permit.parking_zone.name }} <br>
     {% translate "Vehicle" %}: {{ permit.vehicle }} <br>


### PR DESCRIPTION
## Description

At the moment, customer notification email templates are using customer-object directly, causing social security number to be shown in the emails. Remedy this by using customer full name explicitly.

## Context

[PV-627](https://helsinkisolutionoffice.atlassian.net/browse/PV-627)

## How Has This Been Tested?

Manually.

## Manual Testing Instructions for Reviewers

Test by updating permit details in Webshop or in Admin UI.


[PV-627]: https://helsinkisolutionoffice.atlassian.net/browse/PV-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ