### PR TITLE
Enhance Talpa subscription validation

### DIFF
--- a/parking_permits/exceptions.py
+++ b/parking_permits/exceptions.py
@@ -50,6 +50,10 @@ class OrderValidationError(ParkingPermitBaseException):
     pass
 
 
+class SubscriptionValidationError(ParkingPermitBaseException):
+    pass
+
+
 class OrderCancelError(ParkingPermitBaseException):
     pass
 

--- a/parking_permits/services/kami.py
+++ b/parking_permits/services/kami.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
-from rest_framework import status
 
 from parking_permits.exceptions import AddressError
 from parking_permits.models import ParkingZone
@@ -48,7 +47,7 @@ def get_wfs_result(street_name="", street_number_token=""):
 
     response = requests.get(settings.KAMI_URL, params=params)
 
-    if response.status_code != status.HTTP_200_OK:
+    if response.status_code != 200:
         xml_response = xmltodict.parse(response.content)
 
         error_message = (
@@ -94,7 +93,7 @@ def search_address(search_text):
     }
     response = requests.get(settings.KAMI_URL, params=params)
 
-    if response.status_code != status.HTTP_200_OK:
+    if response.status_code != 200:
         xml_response = xmltodict.parse(response.content)
 
         error_message = (

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -178,15 +178,20 @@ def get_permit_prices(
     return permit_prices
 
 
-def get_meta_value(meta_pair_list, meta_pair_key):
+def get_meta_item(meta_pair_list, meta_pair_key):
     return next(
         (
-            meta_pair.get("value")
+            meta_pair
             for meta_pair in meta_pair_list
             if meta_pair.get("key") == meta_pair_key
         ),
         None,
     )
+
+
+def get_meta_value(meta_pair_list, meta_pair_key):
+    item = get_meta_item(meta_pair_list, meta_pair_key)
+    return item.get("value") if item else None
 
 
 def snake_to_camel_dict(dictionary):


### PR DESCRIPTION
## Description

Enhancements:
- Validate Talpa subscription against Talpa Experience API before new subscription creation or existing subscription deletion.
- Always validate order item id existence in Talpa subsription events.
- Always save Talpa order item id to appropriate parking permits application order item based on validated data to increase integration stability.
- Utilize HTTP-status constants across the views-module and related tests.

## Context

[PV-626](https://helsinkisolutionoffice.atlassian.net/browse/PV-626)

## How Has This Been Tested?

Through updated unit tests.


[PV-626]: https://helsinkisolutionoffice.atlassian.net/browse/PV-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ