### PR TITLE
Add checkout_url to GraphQL schema

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -286,6 +286,12 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         return None
 
     @property
+    def checkout_url(self):
+        if self.latest_order and self.latest_order.talpa_checkout_url:
+            return self.latest_order.talpa_checkout_url
+        return None
+
+    @property
     def latest_order_items(self):
         """Get latest order items for the permit"""
         return self.order_items.filter(order=self.latest_order)

--- a/parking_permits/schema/parking_permit.graphql
+++ b/parking_permits/schema/parking_permit.graphql
@@ -71,6 +71,7 @@ type PermitNode {
   addressApartment: String,
   addressApartmentSv: String,
   talpaOrderId: String
+  checkoutUrl: String
   receiptUrl: String
   subscriptionId: String
   vehicle: VehicleNode!

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -19,7 +19,7 @@ from parking_permits.models.product import ProductType
 from parking_permits.models.vehicle import EmissionType
 from parking_permits.tests.factories import ParkingZoneFactory
 from parking_permits.tests.factories.customer import CustomerFactory
-from parking_permits.tests.factories.order import OrderFactory
+from parking_permits.tests.factories.order import OrderFactory, OrderItemFactory
 from parking_permits.tests.factories.parking_permit import ParkingPermitFactory
 from parking_permits.tests.factories.product import ProductFactory
 from parking_permits.tests.factories.vehicle import (
@@ -552,6 +552,14 @@ class TestParkingPermit(TestCase):
 
     def test_should_return_correct_product_name(self):
         self.assertIsNotNone(self.permit.parking_zone.name)
+
+    def test_checkout_url_if_latest_order_none(self):
+        self.assertIsNone(self.permit.checkout_url)
+
+    def test_checkout_url_if_latest_order_not_none(self):
+        item = OrderItemFactory(permit=self.permit)
+        self.permit.orders.add(item.order)
+        self.assertEqual(self.permit.checkout_url, item.order.talpa_checkout_url)
 
     @override_settings(DEBUG_SKIP_PARKKIHUBI_SYNC=False)
     @patch("requests.post", return_value=MockResponse(201))


### PR DESCRIPTION
## Description

Adds `checkout_url` field to parking permit.

## Context


[PV-612](https://helsinkisolutionoffice.atlassian.net/browse/PV-612)

## How Has This Been Tested?

Includes unit tests for `checkout_url` property

## Manual Testing Instructions for Reviewers

`/graphql` endpoint should include `checkout_url` field on each permit.



[PV-612]: https://helsinkisolutionoffice.atlassian.net/browse/PV-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ