### PR TITLE
Always check subscription existence

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -403,10 +403,11 @@ class CustomerPermit:
                     .distinct()
                     .first()
                 )
-                subscription.cancel(
-                    cancel_reason=subscription_cancel_reason,
-                    cancel_from_talpa=cancel_from_talpa,
-                )
+                if subscription:
+                    subscription.cancel(
+                        cancel_reason=subscription_cancel_reason,
+                        cancel_from_talpa=cancel_from_talpa,
+                    )
             else:
                 # Cancel fixed period permit order when this is the last valid permit in that order
                 latest_order = permit.latest_order


### PR DESCRIPTION
## Description

Always check subscription existence before calling its cancel-method.

## Context

[PV-629](https://helsinkisolutionoffice.atlassian.net/browse/PV-629)

## How Has This Been Tested?

Locally.
