### PR TITLE
Improve "right of purchase" Talpa webhook handling

### DIFF
--- a/parking_permits/models/vehicle.py
+++ b/parking_permits/models/vehicle.py
@@ -1,3 +1,5 @@
+import datetime
+
 import arrow
 from django.contrib.gis.db import models
 from django.utils import timezone as tz
@@ -172,7 +174,8 @@ class Vehicle(TimestampedModelMixin):
     def is_due_for_inspection(self):
         return (
             self.last_inspection_date is not None
-            and arrow.utcnow().date() > self.last_inspection_date
+            and arrow.utcnow().date()
+            > datetime.datetime.strptime(self.last_inspection_date, "%Y-%m-%d").date()
         )
 
     @property

--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -11,7 +11,7 @@ from django.utils import timezone as tz
 from freezegun import freeze_time
 from helusers.settings import api_token_auth_settings
 from jose import jwt
-from rest_framework.test import APIClient, APITestCase
+from rest_framework.test import APITestCase
 
 from parking_permits.exceptions import DeletionNotAllowed
 from parking_permits.models.driving_licence import DrivingLicence
@@ -83,9 +83,6 @@ def get_validated_subscription_data(
 
 
 class PaymentViewTestCase(APITestCase):
-    def setUp(self):
-        self.client = APIClient()
-
     def test_payment_view_should_return_bad_request_if_talpa_order_id_missing(self):
         url = reverse("parking_permits:payment-notify")
         data = {
@@ -114,9 +111,6 @@ class PaymentViewTestCase(APITestCase):
 
 
 class RightOfPurchaseViewTestCase(APITestCase):
-    def setUp(self):
-        self.client = APIClient()
-
     def test_right_of_purchase_view_should_return_bad_request_if_talpa_order_id_missing(
         self,
     ):
@@ -360,9 +354,6 @@ class RightOfPurchaseViewTestCase(APITestCase):
 
 
 class OrderViewTestCase(APITestCase):
-    def setUp(self):
-        self.client = APIClient()
-
     def test_order_view_should_return_bad_request_if_talpa_order_id_missing(self):
         url = reverse("parking_permits:order-notify")
         data = {
@@ -465,9 +456,6 @@ class OrderViewTestCase(APITestCase):
 
 
 class SubscriptionViewTestCase(APITestCase):
-    def setUp(self):
-        self.client = APIClient()
-
     def test_subscription_view_should_return_bad_request_if_talpa_order_id_missing(
         self,
     ):

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -219,10 +219,40 @@ class TalpaResolveRightOfPurchase(APIView):
             f"Data received for resolve right of purchase = {json.dumps(request.data, default=str)}"
         )
         order_item_data = request.data.get("orderItem")
+        if not order_item_data:
+            logger.error("Order item data is missing from request data")
+            return Response(
+                {"message": "No order item data is provided"},
+                status=400,
+            )
         order_item_id = order_item_data.get("orderItemId")
+        if not order_item_id:
+            logger.error("Talpa order item id is missing from request data")
+            return Response(
+                {"message": "No order item id is provided"},
+                status=400,
+            )
         meta = order_item_data.get("meta")
+        if not meta:
+            logger.error("Order item metadata is missing from request data")
+            return Response(
+                {"message": "No order item metadata is provided"},
+                status=400,
+            )
         permit_id = get_meta_value(meta, "permitId")
+        if not permit_id:
+            logger.error("Permit id is missing from request data")
+            return Response(
+                {"message": "No permit id is provided"},
+                status=400,
+            )
         user_id = request.data.get("userId")
+        if not user_id:
+            logger.error("User id is missing from request data")
+            return Response(
+                {"message": "No user id is provided"},
+                status=400,
+            )
 
         try:
             permit = ParkingPermit.objects.get(pk=permit_id)


### PR DESCRIPTION
## Description

Improve "right of purchase" Talpa webhook handling.

Updates made:
- Increase input validation
- Add tests for RightOfPurchaseView
- Convert str to date before comparison

## Context

[PV-630](https://helsinkisolutionoffice.atlassian.net/browse/PV-630)

## How Has This Been Tested?

Through added unit tests.


[PV-630]: https://helsinkisolutionoffice.atlassian.net/browse/PV-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ