### PR TITLE
Use vehicle decommissioned status directly

### DIFF
--- a/parking_permits/models/vehicle.py
+++ b/parking_permits/models/vehicle.py
@@ -1,6 +1,3 @@
-import datetime
-
-import arrow
 from django.contrib.gis.db import models
 from django.utils import timezone as tz
 from django.utils.translation import gettext_lazy as _
@@ -170,13 +167,6 @@ class Vehicle(TimestampedModelMixin):
     def save(self, *args, **kwargs):
         self._is_low_emission = self.is_low_emission
         super(Vehicle, self).save(*args, **kwargs)
-
-    def is_due_for_inspection(self):
-        return (
-            self.last_inspection_date is not None
-            and arrow.utcnow().date()
-            > datetime.datetime.strptime(self.last_inspection_date, "%Y-%m-%d").date()
-        )
 
     @property
     def is_low_emission(self):

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -256,7 +256,6 @@ class TalpaResolveRightOfPurchase(APIView):
                 and is_user_of_vehicle
                 and customer.driving_licence.active
                 and has_valid_driving_licence
-                and not vehicle.is_due_for_inspection()
             )
             res = snake_to_camel_dict(
                 {


### PR DESCRIPTION
## Description

When checking vehicle validity, use vehicle decommissioned status directly instead of last inspection date.

## Context

[PV-613](https://helsinkisolutionoffice.atlassian.net/browse/PV-613)

## How Has This Been Tested?

Through added unit test.


[PV-613]: https://helsinkisolutionoffice.atlassian.net/browse/PV-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ