### PR TITLE
Always use permit start- and end-times in permit emails

### DIFF
--- a/parking_permits/templates/emails/_permit_info.html
+++ b/parking_permits/templates/emails/_permit_info.html
@@ -7,9 +7,5 @@
     {% translate "Area" %}: {{ permit.parking_zone.name }} <br>
     {% translate "Vehicle" %}: {{ permit.vehicle }} <br>
     {{ permit.get_contract_type_display }} <br>
-    {% if permit.contract_type == "FIXED_PERIOD" %}
-        {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
-    {% else %}
-        {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.current_period_end_time|date:"j.n.Y, H:i" }}
-    {% endif %}
+    {% translate "Validity period" %}: {{ permit.start_time|date:"j.n.Y, H:i" }} – {{ permit.end_time|date:"j.n.Y, H:i" }}
 </p>


### PR DESCRIPTION
## Description

Always use permit start- and end-times in permit emails.

## Context

[PV-653](https://helsinkisolutionoffice.atlassian.net/browse/PV-653)

## How Has This Been Tested?

Locally.


[PV-653]: https://helsinkisolutionoffice.atlassian.net/browse/PV-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ