### PR TITLE
Set emission to zero if None

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -404,6 +404,8 @@ def update_or_create_vehicle(vehicle_info):
         else None
     )
 
+    emission = vehicle_info.get("emission") or 0
+
     vehicle_data = {
         "registration_number": registration_number,
         "manufacturer": vehicle_info["manufacturer"],
@@ -412,8 +414,8 @@ def update_or_create_vehicle(vehicle_info):
         "serial_number": vehicle_info["serial_number"],
         "vehicle_class": vehicle_info["vehicle_class"],
         "euro_class": vehicle_info["euro_class"],
-        "emission": vehicle_info["emission"],
         "emission_type": vehicle_info["emission_type"],
+        "emission": emission,
         "power_type": power_type,
     }
     return Vehicle.objects.update_or_create(

--- a/parking_permits/schema/parking_permit_admin.graphql
+++ b/parking_permits/schema/parking_permit_admin.graphql
@@ -476,7 +476,7 @@ input VehicleInput {
   consentLowEmissionAccepted: Boolean!
   vehicleClass: String!
   euroClass: Int!
-  emission: Int!
+  emission: Int
   emissionType: String!
   powerType: PowerTypeInput!
 }

--- a/parking_permits/tests/test_admin_resolvers.py
+++ b/parking_permits/tests/test_admin_resolvers.py
@@ -35,6 +35,33 @@ def test_update_or_create_vehicle_should_create_vehicle():
 
 
 @pytest.mark.django_db
+def test_update_or_create_vehicle_emission_none():
+    power_type = VehiclePowerTypeFactory()
+    vehicle_info = dict(
+        registration_number="ABC-123",
+        manufacturer="Manufacturer",
+        model="Model",
+        consent_low_emission_accepted=True,
+        serial_number="123",
+        vehicle_class="M1",
+        euro_class=1,
+        emission=None,
+        emission_type="WLTP",
+        power_type={"identifier": power_type.identifier},
+    )
+
+    vehicle = update_or_create_vehicle(vehicle_info)
+
+    skipped_keys = ["power_type", "emission"]
+    for k, v in vehicle_info.items():
+        if k in skipped_keys:
+            continue
+        assert getattr(vehicle, k) == v
+    assert vehicle.emission == 0
+    assert vehicle.power_type == power_type
+
+
+@pytest.mark.django_db
 def test_update_or_create_vehicle_should_update_vehicle():
     old_power_type = VehiclePowerTypeFactory()
     new_power_type = VehiclePowerTypeFactory()


### PR DESCRIPTION
This change should permit null emission value, and set to zero 

## Description

Removes the strict requirement for not-null int in GraphQL, and set emission to zero if null is passed.

## Context

[PV-641](https://helsinkisolutionoffice.atlassian.net/browse/PV-641)

## How Has This Been Tested?

In admin UI, find a permit+vehicle where emission is None. Submit form without touching the Emission field (Hiilidioksidipäästöt). 

This would previously return an Internal Server Error, now it should update the vehicle with emission zero. Non-zero emission values should be handled as before.

## Manual Testing Instructions for Reviewers

See above



[PV-641]: https://helsinkisolutionoffice.atlassian.net/browse/PV-641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ