### PR TITLE
Handle multiple values and previous vehicles in order search

### DIFF
--- a/parking_permits/tests/factories/vehicle.py
+++ b/parking_permits/tests/factories/vehicle.py
@@ -5,6 +5,7 @@ import factory
 import pytz
 
 from parking_permits.models import Vehicle
+from parking_permits.models.temporary_vehicle import TemporaryVehicle
 from parking_permits.models.vehicle import LowEmissionCriteria, VehiclePowerType
 from parking_permits.tests.factories.faker import fake
 
@@ -52,3 +53,20 @@ class LowEmissionCriteriaFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = LowEmissionCriteria
+
+
+class TemporaryVehicleFactory(factory.django.DjangoModelFactory):
+    vehicle = factory.SubFactory(Vehicle)
+    start_time = factory.LazyFunction(
+        lambda: fake.date_time_between(
+            start_date="-2d", end_date="-1d", tzinfo=pytz.utc
+        )
+    )
+    end_time = factory.LazyFunction(
+        lambda: fake.date_time_between(
+            start_date="+1d", end_date="+2d", tzinfo=pytz.utc
+        )
+    )
+
+    class Meta:
+        model = TemporaryVehicle


### PR DESCRIPTION
This change should allow the following:

1. Include customer's previous vehicles' registrations on other permits in search
2. Include permit's temporary vehicle registration
3. Allow multiple values e.g. "John Smith" rather than a single value


[PV-624](https://helsinkisolutionoffice.atlassian.net/browse/PV-624)

## How Has This Been Tested?

Unit tests



[PV-624]: https://helsinkisolutionoffice.atlassian.net/browse/PV-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ