### PR TITLE
Set end_time when start_time is set

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -298,6 +298,7 @@ class CustomerPermit:
             month_count = data.get("month_count", 1)
             primary, secondary = self._get_primary_and_secondary_permit()
             end_time = get_end_time(primary.start_time, month_count)
+
             if not contract_type:
                 raise InvalidContractType(_("Contract type is required"))
 
@@ -571,6 +572,7 @@ class CustomerPermit:
     def _get_start_type_and_start_time(self, data):
         start_type = data.get("start_type", None)
         start_time = data.get("start_time", next_day())
+        month_count = data.get("month_count", 1)
 
         if start_time and not start_type:
             start_type = FROM
@@ -585,7 +587,12 @@ class CustomerPermit:
                 if parsed.date() > two_week_from_now().date()
                 else parsed
             )
-        return {"start_type": start_type, "start_time": start_time}
+
+        return {
+            "start_type": start_type,
+            "start_time": start_time,
+            "end_time": get_end_time(start_time, diff_months=month_count),
+        }
 
     def _get_month_count_for_secondary_permit(self, contract_type, count):
         if contract_type == OPEN_ENDED:


### PR DESCRIPTION
This should ensure we set the end time whenever the start_time is provided in the permit update.

NOTE: the current end date calculation should calculate one month minus one day from the provided start date and normalize to 23:59 on that date. This calculation has not been changed.

## Context

[PV-670](https://helsinkisolutionoffice.atlassian.net/browse/PV-670)

## How Has This Been Tested?

Tested manually with Webshop UI

## Screenshots

![Screenshot from 2023-10-25 14-41-58](https://github.com/City-of-Helsinki/parking-permits/assets/131681805/ce7ac1a0-03dc-46d3-bf10-0e685d96beb6)


[PV-670]: https://helsinkisolutionoffice.atlassian.net/browse/PV-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ