### PR TITLE
Fix datetime-format to use milliseconds

### DIFF
--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -64,7 +64,7 @@ def get_validated_order_data(talpa_order_id, talpa_order_item_id):
         "items": [
             {
                 "orderItemId": talpa_order_item_id,
-                "startDate": "2023-06-01T15:46:05",
+                "startDate": "2023-06-01T15:46:05.619",
                 "priceGross": "45.00",
                 "rowPriceTotal": "45.00",
                 "vatPercentage": 24,

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -485,7 +485,7 @@ class OrderView(APIView):
 
             start_time = tz.make_aware(
                 datetime.datetime.strptime(
-                    validated_order_item_data.get("startDate"), "%Y-%m-%dT%H:%M:%S"
+                    validated_order_item_data.get("startDate"), "%Y-%m-%dT%H:%M:%S.%f"
                 )
             )
             end_time = get_end_time(start_time, 1)


### PR DESCRIPTION
## Description

Talpa returns milliseconds nowadays in permit start date, so need to adapt to that.
Update also tests.

## Context

[PV-671](https://helsinkisolutionoffice.atlassian.net/browse/PV-671)

## How Has This Been Tested?

Through unit tests.


[PV-671]: https://helsinkisolutionoffice.atlassian.net/browse/PV-671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ