### PR TITLE
Update talpa checkout data labels

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-11 21:01+0300\n"
+"POT-Creation-Date: 2023-10-26 07:26+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -90,7 +90,7 @@ msgid ""
 "ended"
 msgstr ""
 "Määräaikaisen tunnuksen luonti ei ole mahdollista, jos asiakkaalla on jo "
-"voimassa oleva jatkuvavelotteinen tunnus"
+"voimassa oleva jatkuvaveloitteinen tunnus"
 
 msgid "Vehicle registration number is mandatory for the permit"
 msgstr "Ajoneuvon rekisterinumero on pakollinen tietd"
@@ -132,7 +132,7 @@ msgid ""
 "not allowed"
 msgstr ""
 "Tunnuksen osoitteen vaihto ei ole sallittua, jos tunnusten tyyppi on eriävä "
-"(määräaikainen / jatkuvavelotteinen)"
+"(määräaikainen / jatkuvaveloitteinen)"
 
 msgid "Primary permit cannot be ended if customer has two permits"
 msgstr ""
@@ -152,6 +152,9 @@ msgstr "Tilauksen hakuvirhe"
 
 msgid "Address search error"
 msgstr "Osoitteen hakuvirhe"
+
+msgid "This address is already in use"
+msgstr "Tämä osoite on jo käytössä"
 
 msgid "Announcement search error"
 msgstr "Ilmoituksen hakuvirhe"
@@ -514,6 +517,9 @@ msgstr "Ajoneuvo vaihtunut"
 msgid "Address changed"
 msgstr "Osoite vaihtunut"
 
+msgid "Subscription renewed"
+msgstr "Sopimus uusittu"
+
 msgid "Talpa order id"
 msgstr "Talpan tilauksen tunniste"
 
@@ -599,7 +605,7 @@ msgid "Fixed period"
 msgstr "Määräaikainen"
 
 msgid "Open ended"
-msgstr "Jatkuvavelotteinen"
+msgstr "Jatkuvaveloitteinen"
 
 msgid "Immediately"
 msgstr "Heti"
@@ -890,9 +896,6 @@ msgstr "Epäkelpo asiakkaan osoite"
 msgid "Address not found"
 msgstr "Osoitetta ei löytynyt"
 
-msgid "This address is already in use"
-msgstr "Tämä osoite on jo käytössä"
-
 msgid "No active permits for the customer"
 msgstr "Asiakkaalla ei ole aktiivisia tunnuksia"
 
@@ -954,12 +957,15 @@ msgstr ""
 msgid "Failed to fetch data from traficom"
 msgstr "Tietojen haku Traficomilta epäonnistui"
 
-msgid "Duration of parking permit"
-msgstr "Pysäköintitunnuksen kesto"
+msgid "Parking permit type"
+msgstr "Pysäköintitunnuksen tyyppi"
 
 #, python-format
-msgid "Fixed period %(month)d kk"
+msgid "Fixed period %(month)d months"
 msgstr "Määräaikainen %(month)d kk"
+
+msgid "Open ended 1 month"
+msgstr "Jatkuvaveloitteinen 1 kk"
 
 msgid "Parking permit start date*"
 msgstr "Pysäköintitunnuksen alkamispäivä*"
@@ -973,6 +979,9 @@ msgstr ""
 
 msgid "Parking permit expiration date"
 msgstr "Pysäköintitunnuksen päättymispäivä"
+
+msgid "Parking permit period expiration date"
+msgstr "Pysäköintitunnuksen jakson päättymispäivä"
 
 msgid "Failed to create the order"
 msgstr "Tilauksen luonti epäonnistui"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-11 21:06+0300\n"
+"POT-Creation-Date: 2023-10-26 07:26+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,6 +150,9 @@ msgstr "Beställningssökningsfel"
 
 msgid "Address search error"
 msgstr "Adresssökningsfel"
+
+msgid "This address is already in use"
+msgstr "Adressen används redan"
 
 msgid "Announcement search error"
 msgstr "Sökningsfel för meddelande"
@@ -508,6 +511,9 @@ msgstr "Fordon bytt"
 
 msgid "Address changed"
 msgstr "Adress ändrad"
+
+msgid "Subscription renewed"
+msgstr "Avtal förnyad"
 
 msgid "Talpa order id"
 msgstr "Talpa beställning ID"
@@ -887,9 +893,6 @@ msgstr "Inte en giltig kundadress"
 msgid "Address not found"
 msgstr "Adressen hittades inte"
 
-msgid "This address is already in use"
-msgstr "Adressen används redan"
-
 msgid "No active permits for the customer"
 msgstr "Inga aktiva tillstånd för kunden"
 
@@ -953,12 +956,14 @@ msgstr ""
 msgid "Failed to fetch data from traficom"
 msgstr "Datahämtning från Traficomilta misslyckades"
 
-msgid "Duration of parking permit"
-msgstr "Pysäköintitunnuksen kesto"
+msgid "Parking permit type"
+msgstr "Typ av parkeringstillstånd"
 
-#, python-format
-msgid "Fixed period %(month)d kk"
+msgid "Fixed period %(month)d months"
 msgstr "Temporär %(month)d månad"
+
+msgid "Open ended 1 month"
+msgstr "Löpande debitering 1 månad"
 
 msgid "Parking permit start date*"
 msgstr "Tillståndet stardag*"
@@ -971,6 +976,9 @@ msgstr ""
 
 msgid "Parking permit expiration date"
 msgstr "Tillståndet utgångsdatum"
+
+msgid "Parking permit period expiration date"
+msgstr "Tillståndet period utgångsdatum"
 
 msgid "Failed to create the order"
 msgstr "Misslyckades med att skapa beställningen"

--- a/parking_permits/talpa/order.py
+++ b/parking_permits/talpa/order.py
@@ -86,9 +86,12 @@ class TalpaOrderManager:
         item["meta"] += [
             {"key": "permitId", "value": str(permit.id), "visibleInCheckout": False},
             {
-                "key": "permitDuration",
-                "label": _("Duration of parking permit"),
-                "value": _("Fixed period %(month)d kk") % {"month": permit.month_count},
+                "key": "permitType",
+                "label": _("Parking permit type"),
+                "value": _("Fixed period %(month)d months")
+                % {"month": permit.month_count}
+                if permit.is_fixed_period
+                else _("Open ended 1 month"),
                 "visibleInCheckout": True,
                 "ordinal": 1,
             },
@@ -114,7 +117,9 @@ class TalpaOrderManager:
             item["meta"].append(
                 {
                     "key": "endDate",
-                    "label": _("Parking permit expiration date"),
+                    "label": _("Parking permit expiration date")
+                    if permit.is_fixed_period
+                    else _("Parking permit period expiration date"),
                     "value": end_time,
                     "visibleInCheckout": True,
                     "ordinal": 3,

--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -707,7 +707,7 @@ class ResolveRightOfPurchaseViewTestCase(APITestCase):
                         "orderItemMetaId": "9a672f56-2bad-4510-9831-3c4dad12928f",
                         "orderItemId": talpa_order_item_id,
                         "orderId": talpa_order_id,
-                        "key": "permitDuration",
+                        "key": "permitType",
                         "value": "Määräaikainen 1 kk",
                         "label": "Pysäköintitunnuksen kesto",
                         "visibleInCheckout": "true",


### PR DESCRIPTION
## Description

Update Talpa checkout data labels to be more suitable for open ended permits.

## Context

[PV-667](https://helsinkisolutionoffice.atlassian.net/browse/PV-667)
[PV-668](https://helsinkisolutionoffice.atlassian.net/browse/PV-668)

## How Has This Been Tested?

Manually.

## Screenshots

<img width="639" alt="open-ended permit updated labels" src="https://github.com/City-of-Helsinki/parking-permits/assets/2784933/0a256364-ed81-41d9-aadb-93298e5974bf">



[PV-667]: https://helsinkisolutionoffice.atlassian.net/browse/PV-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PV-668]: https://helsinkisolutionoffice.atlassian.net/browse/PV-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ