### PR TITLE
Improve permit text search

### DIFF
--- a/parking_permits/forms.py
+++ b/parking_permits/forms.py
@@ -147,7 +147,7 @@ class PermitSearchForm(SearchFormBase):
                         [
                             Q(customer__first_name__icontains=token)
                             | Q(customer__last_name__icontains=token)
-                            | Q(customer__national_id_number=token)
+                            | Q(customer__national_id_number__iexact=token)
                             | Q(vehicle__registration_number__iexact=q)
                             for token in q.split()[: self.MAX_TEXT_SEARCH_TOKENS]
                         ],

--- a/parking_permits/tests/test_forms.py
+++ b/parking_permits/tests/test_forms.py
@@ -191,6 +191,25 @@ class PermitSearchFormTextSearch(TestCase):
         self.assertEqual(qs.count(), 1)
         self.assertEqual(qs.first(), permit)
 
+    def test_search_customer_national_id_number_mixed_case(self):
+        customer = CustomerFactory(
+            first_name="Seppo",
+            last_name="Taalasmaa",
+            national_id_number="02051951-a111b",
+        )
+
+        permit = ParkingPermitFactory(
+            customer=customer,
+        )
+
+        form = PermitSearchForm({"q": customer.national_id_number})
+
+        self.assertTrue(form.is_valid())
+
+        qs = form.get_queryset()
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs.first(), permit)
+
     def test_search_customer_national_id_number_with_inspector_role(self):
         customer = CustomerFactory(
             first_name="Seppo",


### PR DESCRIPTION
## Description

- Improve permit text search to function similarly as the current Orders-search
- Use a case-insensitive match with vehicle registration number
- Add tests for permit search form text search

## Context

[PV-661](https://helsinkisolutionoffice.atlassian.net/browse/PV-661)

## How Has This Been Tested?

With added unit tests and manually.

## Screenshots

<img width="1294" alt="permit search lower case vehicle registration number" src="https://github.com/City-of-Helsinki/parking-permits/assets/2784933/caf43983-3c9b-4ef0-8ed5-edfe49031928">



[PV-661]: https://helsinkisolutionoffice.atlassian.net/browse/PV-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ