### PR TITLE
Remove Traficom checks from PASI CSV-import

### DIFF
--- a/parking_permits/management/commands/import_pasi_csv.py
+++ b/parking_permits/management/commands/import_pasi_csv.py
@@ -17,8 +17,8 @@ from django.utils import timezone
 from parking_permits.models import Address, Customer, Order, ParkingPermit, Vehicle
 from parking_permits.models.order import OrderStatus
 from parking_permits.models.parking_permit import ContractType, ParkingPermitStatus
+from parking_permits.models.vehicle import VehicleUser
 from parking_permits.services import dvv, kami
-from parking_permits.services.traficom import Traficom
 
 # E.g. 1.1.2011 1:01, 31.12.2012 15:50
 PASI_DATETIME_FORMAT = re.compile(
@@ -244,7 +244,14 @@ class Command(BaseCommand):
         # Validation & initialization
         person_info = self.get_person_info(pasi_permit.national_id_number)
         permit_address_type = self.find_permit_address_type(pasi_permit, person_info)
-        vehicle = self.fetch_vehicle(pasi_permit.registration_number)
+        vehicle = Vehicle.objects.get_or_create(
+            registration_number=pasi_permit.registration_number.strip()
+        )[0]
+        vehicle.users.add(
+            VehicleUser.objects.get_or_create(
+                national_id_number=pasi_permit.national_id_number.strip()
+            )[0]
+        )
         self.validate_vehicle(pasi_permit, vehicle)
 
         # Create/get all the instances required for a parking permit.
@@ -407,15 +414,6 @@ class Command(BaseCommand):
         )
 
         return customer
-
-    @staticmethod
-    def fetch_vehicle(registration_number: str) -> Vehicle:
-        try:
-            return Traficom().fetch_vehicle_details(registration_number)
-        except Exception as e:
-            raise PasiImportError(
-                "Something went wrong during Traficom vehicle fetch"
-            ) from e
 
     @staticmethod
     def validate_vehicle(pasi_permit: PasiResidentPermit, vehicle: Vehicle) -> NoReturn:

--- a/parking_permits/tests/commands/test_import_pasi_csv.py
+++ b/parking_permits/tests/commands/test_import_pasi_csv.py
@@ -318,25 +318,6 @@ class TestPasiImportCommand:
         with pytest.raises(PasiValidationError):
             PasiCommand.validate_vehicle(pasi_resident_permit, vehicle)
 
-    @patch.object(Traficom, "fetch_vehicle_details", return_value="Hello, world!")
-    def test_fetch_vehicle_gets_vehicle_from_traficom(self, mock_fetch_vehicle_details):
-        vehicle = PasiCommand.fetch_vehicle("FOO-123")
-
-        mock_fetch_vehicle_details.assert_called_once_with("FOO-123")
-        assert vehicle == "Hello, world!"
-
-    @patch.object(Traficom, "fetch_vehicle_details", return_value="Hello, world!")
-    def test_fetch_vehicle_raises_pasi_error_on_failure(
-        self, mock_fetch_vehicle_details
-    ):
-        def raise_error(*_, **__):
-            raise ValueError
-
-        mock_fetch_vehicle_details.side_effect = raise_error
-
-        with pytest.raises(PasiImportError):
-            PasiCommand.fetch_vehicle("FOO-123")
-
     def test_vehicle_has_active_permits_returns_true_if_has_active_permits(self):
         vehicle = VehicleFactory(registration_number="FOO-123")
         ParkingPermitFactory(status=ParkingPermitStatus.VALID, vehicle=vehicle)


### PR DESCRIPTION
## Description

Remove Traficom checks from PASI CSV-import.

According to the latest specification, we do not need to validate PASI-permit vehicles against the Traficom API. Instead, we just use the vehicle registration number to create vehicles.

## Context

[PV-628](https://helsinkisolutionoffice.atlassian.net/browse/PV-628)

## How Has This Been Tested?

With unit tests.


[PV-628]: https://helsinkisolutionoffice.atlassian.net/browse/PV-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ