### PR TITLE
Talpa Order renewal fixes

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -911,8 +911,8 @@ msgstr "Sinulle on luotu pysäköintitunnus"
 msgid "Your parking permit information has been updated"
 msgstr "Pysäköintitunnuksen tiedot on päivitetty"
 
-msgid "Your order has ended"
-msgstr "Tilauksesi on päättynyt"
+msgid "Your order will end"
+msgstr "Tilauksesi päättyy"
 
 msgid "Temporary vehicle attached to your permit"
 msgstr "Tilapäinen ajoneuvo liitetty tunnukseen"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -336,7 +336,7 @@ msgid "Refund ID"
 msgstr "Återbetalning ID"
 
 msgid "incl. VAT"
-msgstr "ink. MOMS"
+msgstr "inkl. MOMS"
 
 msgid "Extra info"
 msgstr "Ytterligare uppgifter"
@@ -908,8 +908,8 @@ msgstr "Nytt parkeringstillstånd har skapats åt dig"
 msgid "Your parking permit information has been updated"
 msgstr "Parkeringtillståndet informationen har uppdaterats"
 
-msgid "Your order has ended"
-msgstr "Er tillståndet har slutat"
+msgid "Your order will end"
+msgstr "Ditt parkeringstillstånd kommer att avslutas"
 
 msgid "Temporary vehicle attached to your permit"
 msgstr "Tillfälligt fordon kopplat till ditt tillstånd"

--- a/parking_permits/services/mail.py
+++ b/parking_permits/services/mail.py
@@ -26,7 +26,7 @@ permit_email_subjects = {
     % (SUBJECT_PREFIX, _("New parking permit has been created for you")),
     PermitEmailType.UPDATED: "%s: %s"
     % (SUBJECT_PREFIX, _("Your parking permit information has been updated")),
-    PermitEmailType.ENDED: "%s: %s" % (SUBJECT_PREFIX, _("Your order has ended")),
+    PermitEmailType.ENDED: "%s: %s" % (SUBJECT_PREFIX, _("Your order will end")),
     PermitEmailType.TEMP_VEHICLE_ACTIVATED: "%s: %s"
     % (SUBJECT_PREFIX, _("Temporary vehicle attached to your permit")),
     PermitEmailType.TEMP_VEHICLE_DEACTIVATED: "%s: %s"

--- a/parking_permits/templates/emails/permit_ended.html
+++ b/parking_permits/templates/emails/permit_ended.html
@@ -1,7 +1,7 @@
 {% extends "emails/base.html" %}
 {% load i18n %}
 
-{% block title %}{% translate "Your order has ended" %}{% endblock %}
+{% block title %}{% translate "Your order will end" %}{% endblock %}
 
 {% block content %}
     <p>

--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -1429,6 +1429,66 @@ class SubscriptionViewTestCase(APITestCase):
         self.assertEqual(refund.name, permit.customer.full_name)
         self.assertEqual(refund.status, RefundStatus.OPEN)
 
+    @override_settings(DEBUG=True)
+    @patch.object(OrderValidator, "validate_order")
+    @freeze_time("2023-05-30")
+    def test_subscription_cancellation_already_cancelled(self, mock_validate_order):
+        talpa_order_id = "d86ca61d-97e9-410a-a1e3-4894873b1b35"
+        talpa_order_item_id = "819daecd-5ebb-4a94-924e-9710069e9285"
+        talpa_subscription_id = "f769b803-0bd0-489d-aa81-b35af391f391"
+        customer = CustomerFactory()
+        permit_start_time = datetime.datetime(
+            2023, 3, 16, 10, 00, 0, tzinfo=datetime.timezone.utc
+        )
+        permit_end_time = datetime.datetime(
+            2023, 7, 15, 23, 59, 0, tzinfo=datetime.timezone.utc
+        )
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            customer=customer,
+            start_time=permit_start_time,
+            end_time=permit_end_time,
+        )
+        order = OrderFactory(
+            talpa_order_id=talpa_order_id,
+            customer=customer,
+            status=OrderStatus.CONFIRMED,
+        )
+        order.permits.add(permit)
+        order.save()
+        unit_price = Decimal(30)
+        product = ProductFactory(unit_price=unit_price)
+        subscription = SubscriptionFactory(
+            talpa_subscription_id=talpa_subscription_id,
+            status=SubscriptionStatus.CANCELLED,
+        )
+        OrderItemFactory(
+            order=order,
+            product=product,
+            permit=permit,
+            subscription=subscription,
+        )
+
+        url = reverse("parking_permits:subscription-notify")
+        data = {
+            "eventType": "SUBSCRIPTION_CANCELLED",
+            "subscriptionId": talpa_subscription_id,
+            "orderId": talpa_order_id,
+            "orderItemId": talpa_order_item_id,
+        }
+
+        mock_validate_order.return_value = get_validated_order_data(
+            talpa_order_id, order.order_items.first().talpa_order_item_id
+        )
+
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        subscription.refresh_from_db()
+        subscription_order = subscription.order_items.first().order
+        self.assertEqual(str(subscription.talpa_subscription_id), talpa_subscription_id)
+        self.assertEqual(str(subscription_order.talpa_order_id), talpa_order_id)
+        self.assertEqual(subscription.status, SubscriptionStatus.CANCELLED)
+
 
 @override_settings(
     OIDC_API_TOKEN_AUTH={

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -523,6 +523,10 @@ class OrderView(APIView):
                 return not_found_response(
                     f"Subscription {talpa_subscription_id} does not exist"
                 )
+            if Order.objects.filter(talpa_order_id=talpa_order_id).exists():
+                return ok_response(
+                    f"Subscription {talpa_subscription_id} already renewed with order {talpa_order_id}"
+                )
             order_item = subscription.order_items.first()
             permit = order_item.permit
 

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -97,6 +97,11 @@ audit_logger = audit.getAuditLoggerAdapter(
 )
 
 
+def ok_response(message):
+    logger.info(message)
+    return Response({"message": message}, status=200)
+
+
 def bad_request_response(message):
     logger.error(message)
     return Response({"message": message}, status=400)
@@ -712,6 +717,10 @@ class SubscriptionView(APIView):
             except Subscription.DoesNotExist:
                 return not_found_response(
                     f"Subscription {talpa_subscription_id} does not exist"
+                )
+            if subscription.status == SubscriptionStatus.CANCELLED:
+                return ok_response(
+                    f"Subscription {talpa_subscription_id} is already cancelled"
                 )
             order_item = subscription.order_items.first()
             permit = order_item.permit


### PR DESCRIPTION
## Description

Fix the following Order renewal issues:

- Skip Subscription renewal, if the new order already exists in the application
- Skip Subscription cancellation, if already cancelled

Also update permit ending email titles.

## Context

[PV-693](https://helsinkisolutionoffice.atlassian.net/browse/PV-693)

## How Has This Been Tested?

Through added unit tests.


[PV-693]: https://helsinkisolutionoffice.atlassian.net/browse/PV-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ