### PR TITLE
Always bypass Talpa order cancel event handling

### DIFF
--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -1016,6 +1016,16 @@ class OrderViewTestCase(APITestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 404)
 
+    def test_order_cancellation(self):
+        url = reverse("parking_permits:order-notify")
+        data = {
+            "eventType": "ORDER_CANCELLED",
+            "orderId": "d86ca61d-97e9-410a-a1e3-4894873b1b35",
+            "subscriptionId": "f769b803-0bd0-489d-aa81-b35af391f391",
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+
     @override_settings(DEBUG=True)
     @patch.object(OrderValidator, "validate_order")
     def test_subscription_renewal(self, mock_validate_order):

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -510,6 +510,10 @@ class OrderView(APIView):
         talpa_subscription_id = request.data.get("subscriptionId")
         event_type = request.data.get("eventType")
 
+        # Always bypass Order cancelled event
+        if event_type == "ORDER_CANCELLED":
+            return ok_response(f"Order {talpa_order_id} cancel bypassed")
+
         if not talpa_order_id:
             return bad_request_response("Talpa order id is missing from request data")
         if not talpa_subscription_id:


### PR DESCRIPTION
## Description

Order and permit cancellation is already handled in subscription cancel event handling.
Therefore always bypass Talpa order cancel event handling and return HTTP status 200 for these events.

## Context

[PV-694](https://helsinkisolutionoffice.atlassian.net/browse/PV-694)

## How Has This Been Tested?

Through added unit test.


[PV-694]: https://helsinkisolutionoffice.atlassian.net/browse/PV-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ