### PR TITLE
Set default emission value from Traficom to 0 if none found.

### DIFF
--- a/parking_permits/services/traficom.py
+++ b/parking_permits/services/traficom.py
@@ -146,7 +146,7 @@ class Traficom:
             "weight": int(weight.text) if weight else 0,
             "registration_number": registration_number,
             "euro_class": 6,  # It will always be 6 class atm.
-            "emission": float(co2emission) if co2emission else None,
+            "emission": float(co2emission) if co2emission else 0,
             "emission_type": emission_type,
             "serial_number": vehicle_serial_number.text,
             "last_inspection_date": last_inspection_date.text


### PR DESCRIPTION
Currently default CO2 emission value from Traficom is None if no suitable value found, should always a number.


## Context


[PV-699](https://helsinkisolutionoffice.atlassian.net/browse/PV-699)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

In admin UI, create a new permit. Choose user 290200A905H and vehicle BCI-770. This should set emission zero.

It should be possible to increment the month count and see updated price.



## Screenshots

![Screenshot from 2023-11-10 14-01-12](https://github.com/City-of-Helsinki/parking-permits/assets/131681805/c0832336-df87-4823-81f3-72840d853aca)


[PV-699]: https://helsinkisolutionoffice.atlassian.net/browse/PV-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ