### PR TITLE
When checking if vehicle is low-emission, check 0 as well as None

### DIFF
--- a/parking_permits/models/vehicle.py
+++ b/parking_permits/models/vehicle.py
@@ -47,7 +47,7 @@ def is_low_emission_vehicle(power_type, euro_class, emission_type, emission):
 
     if (
         not euro_class
-        or emission is None
+        or emission in (None, 0)
         or euro_class < le_criteria.euro_min_class_limit
     ):
         return False

--- a/parking_permits/tests/models/test_vehicle.py
+++ b/parking_permits/tests/models/test_vehicle.py
@@ -63,6 +63,11 @@ class TestIsLowEmissionVehicle(TestCase):
 
         self.assertIsLowEmissionVehicle(self.vehicle, False)
 
+    def test_should_return_false_if_emission_is_zero(self):
+        self.vehicle.emission = 0
+
+        self.assertIsLowEmissionVehicle(self.vehicle, False)
+
     def test_should_return_false_if_euro_class_below_min_class_limit(self):
         self.vehicle.euro_class = 1
 
@@ -74,7 +79,7 @@ class TestIsLowEmissionVehicle(TestCase):
         self.vehicle.emission_type = EmissionType.NEDC
 
         # emission < max limit
-        self.vehicle.emission = 0
+        self.vehicle.emission = 1
         self.assertIsLowEmissionVehicle(self.vehicle, True)
 
         # emission == max limit
@@ -93,7 +98,7 @@ class TestIsLowEmissionVehicle(TestCase):
         self.vehicle.emission_type = EmissionType.WLTP
 
         # emission < max limit
-        self.vehicle.emission = 0
+        self.vehicle.emission = 1
         self.assertIsLowEmissionVehicle(self.vehicle, True)
 
         # emission == max limit


### PR DESCRIPTION
This should handle all non-electric vehicles correctly, as non-electric vehicles should not have emission zero.


## Description

<!-- Describe your changes in detail -->

## Context

[PV-708](https://helsinkisolutionoffice.atlassian.net/browse/PV-708)

## How Has This Been Tested?

Additional unit tests 

## Manual Testing Instructions for Reviewers

Create a new permit in Webshop UI, and select different vehicles. Example: user 290200A905H and vehicle BCI-770.

Cost should be calculated correctly as a high-emission vehicle, even though emission is resolved to 0.

## Screenshots

![Screenshot from 2023-11-13 09-22-36](https://github.com/City-of-Helsinki/parking-permits/assets/131681805/e3bf3d20-4c3c-4d8f-90a2-997ecb47193e)


[PV-708]: https://helsinkisolutionoffice.atlassian.net/browse/PV-708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ