### PR TITLE
Handle open ended permit price change month count

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -423,6 +423,12 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
             price_change_vat = (diff_price * new_product.vat).quantize(
                 Decimal("0.0001")
             )
+            # if the permit ends more than a month from now, count this month
+            diff_months = (
+                relativedelta(timezone.localdate(self.end_time), timezone.localdate())
+            ).months
+            month_count = 1 if diff_months > 0 else 0
+
             return [
                 {
                     "product": new_product.name,
@@ -432,7 +438,7 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
                     "price_change": diff_price,
                     "start_date": start_date,
                     "end_date": end_date,
-                    "month_count": 1,
+                    "month_count": month_count,
                 }
             ]
 


### PR DESCRIPTION
Currently month_count in price change list is always 1 for open ended permit. This should always be 0, unless the end date is more than a month in the future.

**NOTE** This will likely require additional fixes in Webshop UI.

## Context

[PV-710](https://helsinkisolutionoffice.atlassian.net/browse/PV-710)

## How Has This Been Tested?

Unit tests

## Manual Testing Instructions for Reviewers

Create open ended permit, starting immediately, high emission vehicle

Change to low emission vehicle

No Refund should be created


[PV-710]: https://helsinkisolutionoffice.atlassian.net/browse/PV-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ