### PR TITLE
Add canBeRefunded to webshop GraphQL schema

### DIFF
--- a/parking_permits/schema/parking_permit.graphql
+++ b/parking_permits/schema/parking_permit.graphql
@@ -91,6 +91,7 @@ type PermitNode {
   primaryVehicle: Boolean
   monthsLeft: Int
   currentPeriodEndTime: String
+  canBeRefunded: Boolean
   canEndImmediately: Boolean
   canEndAfterCurrentPeriod: Boolean
   hasRefund: Boolean


### PR DESCRIPTION
This uses property ParkingPermit.can_be_refunded, so we can check logic in frontend if a refund is needed when ending or editing a permit.

## Context

[PV-734](https://helsinkisolutionoffice.atlassian.net/browse/PV-734)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

Create an open ended permit, starting immediately, high emission vehicle

Change to low emission vehicle

No refund preview page should be shown, redirects to permits page, no refunds handled in backend.



[PV-734]: https://helsinkisolutionoffice.atlassian.net/browse/PV-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ