### PR TITLE
Add totalRefundAmount to webshop permit GraphQL

### DIFF
--- a/parking_permits/schema/parking_permit.graphql
+++ b/parking_permits/schema/parking_permit.graphql
@@ -98,6 +98,7 @@ type PermitNode {
   vehicleChanged: Boolean
   zoneChanged: Boolean
   isOrderConfirmed: Boolean
+  totalRefundAmount: Float
 }
 
 type PermitPriceChangeItem {


### PR DESCRIPTION
## Context


[PV-736](https://helsinkisolutionoffice.atlassian.net/browse/PV-736)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

In webshop, create and then end permits:

1) Fixed permit, 1 month ahead, start now (=0 Refunds)
2) Fixed permit, 3 months ahead, start now (=2 months refunds)
3) Open permit (=0 refunds)

Refund amount  at cancel should be same as the amount actually refunded in the database, i.e. if 120 EUR is refunded in the DB/backend, then 120 EUR should be shown in the intermediate End Permit refund summary.

[PV-736]: https://helsinkisolutionoffice.atlassian.net/browse/PV-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ