### PR TITLE
When calculating product prices, apply 2nd vehicle premium to base_price

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -495,20 +495,20 @@ class CustomerPermit:
         product = product_with_qty[0]
         quantity = product_with_qty[1]
 
-        base_price = unit_price = product.unit_price
-        discount_price = base_price - (product.low_emission_discount * base_price)
-
-        if permit.vehicle.is_low_emission:
-            unit_price = discount_price
+        base_price = product.unit_price
 
         if not permit.primary_vehicle:
             increase = decimal.Decimal(SECONDARY_VEHICLE_PRICE_INCREASE) / 100
-            unit_price += increase * unit_price
+            base_price += increase * base_price
+
+        discount_price = base_price - (product.low_emission_discount * base_price)
+        unit_price = discount_price if permit.vehicle.is_low_emission else base_price
 
         product.base_price = base_price
         product.discount_price = discount_price
-        product.quantity = quantity
+
         product.unit_price = unit_price
+        product.quantity = quantity
         product.total_price = unit_price * quantity
 
         return product


### PR DESCRIPTION
This change applies the 2nd vehicle premium to the base price, rather than the unit price.

The discount price is then calculated from that base price, and the unit price (base or discount price) is applied based on emission type.

The reason we want to modify the base price is because any vehicle change in the webshop is applied to the base price, so when changing the vehicle for a secondary permit we want the base and discount prices to include the 2nd vehicle premium.


## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-737](https://helsinkisolutionoffice.atlassian.net/browse/PV-737)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

In webshop:

1) Purchase 2 permits: 2nd vehicle should have correct base and low emission prices (x1.5 the normal price)
2) Change vehicle for 2nd permit: the new vehicle again should have full/low emission prices (x1.5 the normal price)

## Screenshots

![Screenshot from 2023-12-08 11-25-53](https://github.com/City-of-Helsinki/parking-permits/assets/131681805/49989a28-3741-4d01-bce2-5d64f34e2523)


[PV-737]: https://helsinkisolutionoffice.atlassian.net/browse/PV-737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ