### PR TITLE
Add extra check if permit is refundable: if open ended and end time > 1

### DIFF
--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -2,7 +2,6 @@ import logging
 from urllib.parse import urljoin
 
 import requests
-from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models, transaction
@@ -591,8 +590,7 @@ class Subscription(SerializableMixin, TimestampedModelMixin, UserStampedModelMix
         self.cancel_reason = cancel_reason
         self.save()
 
-        # Create a refund for a remaining full month period, if it was charged already
-        if permit.end_time and permit.end_time - relativedelta(months=1) > tz.now():
+        if permit.can_be_refunded:
             logger.info(f"Creating Refund for permit {str(permit.id)}")
             refund = Refund.objects.create(
                 name=permit.customer.full_name,


### PR DESCRIPTION

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-738](https://helsinkisolutionoffice.atlassian.net/browse/PV-738)

## How Has This Been Tested?

Tested manually + additional unit tests

## Manual Testing Instructions for Reviewers

1. Create open ended permit in webshop, starting manually
2. In Django admin, adjust permit end time to > 1 month from now
3. End permit in Webshop

Note: subscription has to be created by Talpa, so might not work locally and has to be tested again in QA. Refunds are created from subscriptions.




[PV-738]: https://helsinkisolutionoffice.atlassian.net/browse/PV-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ