### PR TITLE
Traficom error message fixes

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -318,8 +318,8 @@ msgstr "Helsingin kaupunki"
 msgid "Personal data - Digital and population data services agency"
 msgstr "Henkilötiedot - Digi- ja väestötietovirasto"
 
-msgid "Vehicle information - Transport register, Traficom"
-msgstr "Ajoneuvon tiedot - Liikenneasioidenrekisteri, Traficom"
+msgid "Source: Transport register, Traficom"
+msgstr "Lähde: Liikenneasioidenrekisteri, Traficom"
 
 msgid "Permit ID"
 msgstr "Tunniste"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -313,8 +313,8 @@ msgstr "Helsingfors stad"
 msgid "Personal data - Digital and population data services agency"
 msgstr "Personuppgifter - Digital- och befolkningsdatatjänstbyrå"
 
-msgid "Vehicle information - Transport register, Traficom"
-msgstr "Fordonsuppgifter - Trafik- och transportregistret, Traficom"
+msgid "Source: Transport register, Traficom"
+msgstr "Källä: Trafik- och transportregistret, Traficom"
 
 msgid "Permit ID"
 msgstr "Permit ID"

--- a/parking_permits/error_formatter.py
+++ b/parking_permits/error_formatter.py
@@ -1,16 +1,25 @@
 from ariadne import format_error
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext as _
 
-from parking_permits.exceptions import ParkingPermitBaseException
+from parking_permits.exceptions import (
+    ParkingPermitBaseException,
+    TraficomFetchVehicleError,
+)
 
 
 def error_formatter(error, debug):
-    formatted = format_error(error, debug)
-    if isinstance(error.original_error, ParkingPermitBaseException):
-        formatted["message"] = str(error.original_error)
-    elif isinstance(error.original_error, PermissionDenied):
-        formatted["message"] = _("Forbidden")
-    else:
-        formatted["message"] = _("Internal Server Error")
-    return formatted
+    return {
+        **format_error(error, debug),
+        "message": get_error_message(error.original_error),
+    }
+
+
+def get_error_message(exc):
+    if isinstance(exc, TraficomFetchVehicleError):
+        return f"{exc}\n{_('Source: Transport register, Traficom')}"
+    if isinstance(exc, ParkingPermitBaseException):
+        return str(exc)
+    if isinstance(exc, PermissionDenied):
+        return _("Forbidden")
+    return _("Internal Server Error")

--- a/parking_permits/exporters.py
+++ b/parking_permits/exporters.py
@@ -198,7 +198,7 @@ class DataExporter:
                     "© " + _("City of Helsinki") + ", ",
                     _("Personal data - Digital and population data services agency")
                     + ", ",
-                    _("Vehicle information - Transport register, Traficom")
+                    _("Source: Transport register, Traficom")
                     + " "
                     + str(CURRENT_YEAR),
                 }
@@ -235,7 +235,7 @@ class BasePDF(FPDF, metaclass=abc.ABCMeta):
         self.cell(
             0,
             5,
-            _("Vehicle information - Transport register, Traficom")
+            _("Source: Transport register, Traficom")
             + " "
             + str(CURRENT_YEAR),
             0,

--- a/parking_permits/exporters.py
+++ b/parking_permits/exporters.py
@@ -198,9 +198,7 @@ class DataExporter:
                     "© " + _("City of Helsinki") + ", ",
                     _("Personal data - Digital and population data services agency")
                     + ", ",
-                    _("Source: Transport register, Traficom")
-                    + " "
-                    + str(CURRENT_YEAR),
+                    _("Source: Transport register, Traficom") + " " + str(CURRENT_YEAR),
                 }
             }
         }
@@ -235,9 +233,7 @@ class BasePDF(FPDF, metaclass=abc.ABCMeta):
         self.cell(
             0,
             5,
-            _("Source: Transport register, Traficom")
-            + " "
-            + str(CURRENT_YEAR),
+            _("Source: Transport register, Traficom") + " " + str(CURRENT_YEAR),
             0,
             1,
         )

--- a/parking_permits/talpa/order.py
+++ b/parking_permits/talpa/order.py
@@ -99,7 +99,7 @@ class TalpaOrderManager:
             {
                 "key": "copyright",
                 "label": "",
-                "value": f'© {_("Vehicle information - Transport register, Traficom")}',
+                "value": _("Source: Transport register, Traficom"),
                 "visibleInCheckout": True,
                 "ordinal": 5,
             },


### PR DESCRIPTION


## Context

[PV-740](https://helsinkisolutionoffice.atlassian.net/browse/PV-740)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

In admin UI, search for an invalid registration number (e.g. decommissioned) that triggers an error message from Traficom service.

## Screenshots

![Screenshot from 2023-12-12 13-12-36](https://github.com/City-of-Helsinki/parking-permits/assets/131681805/5d0f52bb-a758-463b-889a-935da8775474)


[PV-740]: https://helsinkisolutionoffice.atlassian.net/browse/PV-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ