### PR TITLE
Remove Traficom attributions from PDF and CSV files.

### DIFF
--- a/parking_permits/exporters.py
+++ b/parking_permits/exporters.py
@@ -195,10 +195,8 @@ class DataExporter:
         return {
             "metadata": {
                 "copyright": {
-                    "© " + _("City of Helsinki") + ", ",
-                    _("Personal data - Digital and population data services agency")
-                    + ", ",
-                    _("Source: Transport register, Traficom") + " " + str(CURRENT_YEAR),
+                    "© " + _("City of Helsinki"),
+                    _("Personal data - Digital and population data services agency"),
                 }
             }
         }
@@ -229,13 +227,6 @@ class BasePDF(FPDF, metaclass=abc.ABCMeta):
         self.cell(0, 5, "© " + _("City of Helsinki"), 0, 1)
         self.cell(
             0, 5, _("Personal data - Digital and population data services agency"), 0, 1
-        )
-        self.cell(
-            0,
-            5,
-            _("Source: Transport register, Traficom") + " " + str(CURRENT_YEAR),
-            0,
-            1,
         )
 
     @abc.abstractmethod


### PR DESCRIPTION

## Context

[PV-753](https://helsinkisolutionoffice.atlassian.net/browse/PV-753)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

Download any CSV file from Admin UI reports, or PDF file from the permit detail page.

## Screenshots

![Screenshot from 2023-12-21 13-49-45](https://github.com/City-of-Helsinki/parking-permits/assets/131681805/3fa12348-b24f-48a0-888a-2c5408a448ed)


[PV-753]: https://helsinkisolutionoffice.atlassian.net/browse/PV-753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ