### PR TITLE
Update VAT and net price calculations for individual orders.

### DIFF
--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -18,6 +18,8 @@ from ..exceptions import (
 )
 from ..services.mail import RefundEmailType, send_refund_email
 from ..utils import (
+    calc_net_price,
+    calc_vat_price,
     diff_months_ceil,
     end_date_to_datetime,
     get_meta_item,
@@ -696,19 +698,19 @@ class OrderItem(SerializableMixin, TimestampedModelMixin):
 
     @property
     def total_price_net(self):
-        return self.total_price * (1 - self.vat)
+        return calc_net_price(self.total_price, self.vat)
 
     @property
     def total_price_vat(self):
-        return self.total_price * self.vat
+        return calc_vat_price(self.total_price, self.vat)
 
     @property
     def payment_unit_price_net(self):
-        return self.payment_unit_price * (1 - self.vat)
+        return calc_net_price(self.payment_unit_price, self.vat)
 
     @property
     def payment_unit_price_vat(self):
-        return self.payment_unit_price * self.vat
+        return calc_vat_price(self.payment_unit_price, self.vat)
 
     @property
     def total_payment_price(self):
@@ -716,11 +718,11 @@ class OrderItem(SerializableMixin, TimestampedModelMixin):
 
     @property
     def total_payment_price_net(self):
-        return self.total_payment_price * (1 - self.vat)
+        return calc_net_price(self.total_payment_price, self.vat)
 
     @property
     def total_payment_price_vat(self):
-        return self.total_payment_price * self.vat
+        return calc_vat_price(self.total_payment_price, self.vat)
 
     @property
     def timeframe(self):

--- a/parking_permits/models/product.py
+++ b/parking_permits/models/product.py
@@ -11,7 +11,13 @@ from django.utils.translation import gettext_lazy as _
 
 from parking_permits.exceptions import CreateTalpaProductError, ProductCatalogError
 
-from ..utils import diff_months_ceil, find_next_date, round_up
+from ..utils import (
+    calc_net_price,
+    calc_vat_price,
+    diff_months_ceil,
+    find_next_date,
+    round_up,
+)
 from .mixins import TimestampedModelMixin, UserStampedModelMixin
 from .parking_zone import ParkingZone
 
@@ -186,12 +192,13 @@ class Product(TimestampedModelMixin, UserStampedModelMixin):
         }
         """
         price_gross = self.get_modified_unit_price(is_low_emission, is_secondary)
-        price_net = price_gross / Decimal(1 + (self.vat or 0))
+        price_net = calc_net_price(price_gross, self.vat)
+        price_vat = calc_vat_price(price_gross, self.vat)
 
         return {
             "price_gross": round_up(price_gross),
             "price_net": round_up(price_net),
-            "price_vat": round_up(price_gross - price_net),
+            "price_vat": round_up(price_vat),
         }
 
     def get_merchant_id(self):

--- a/parking_permits/tests/models/test_order.py
+++ b/parking_permits/tests/models/test_order.py
@@ -255,10 +255,10 @@ class TestOrder(TestCase):
         self.assertAlmostEqual(self.order.total_price, Decimal(160))
 
     def test_should_return_correct_total_price_net(self):
-        self.assertAlmostEqual(self.order.total_price_net, Decimal(98))
+        self.assertAlmostEqual(self.order.total_price_net, Decimal(116), delta=1.0)
 
     def test_should_return_correct_total_price_vat(self):
-        self.assertAlmostEqual(self.order.total_price_vat, Decimal(62))
+        self.assertAlmostEqual(self.order.total_price_vat, Decimal(43), delta=1.0)
 
 
 class TestOrderItem(TestCase):
@@ -280,7 +280,7 @@ class TestOrderItem(TestCase):
         self.assertAlmostEqual(self.order_item.total_price, Decimal(60))
 
     def test_should_return_correct_total_price_net(self):
-        self.assertAlmostEqual(self.order_item.total_price_net, Decimal(48))
+        self.assertAlmostEqual(self.order_item.total_price_net, Decimal(50), delta=1.0)
 
     def test_should_return_correct_total_price_vat(self):
-        self.assertAlmostEqual(self.order_item.total_price_vat, Decimal(12))
+        self.assertAlmostEqual(self.order_item.total_price_vat, Decimal(10), delta=1.0)

--- a/parking_permits/tests/test_utils.py
+++ b/parking_permits/tests/test_utils.py
@@ -1,5 +1,6 @@
 import zoneinfo
 from datetime import date, datetime
+from decimal import Decimal
 
 import pytest
 from django.test import TestCase
@@ -8,6 +9,8 @@ from parking_permits.models import Vehicle
 from parking_permits.tests.factories.vehicle import VehicleFactory
 from parking_permits.utils import (
     ModelDiffer,
+    calc_net_price,
+    calc_vat_price,
     date_time_to_helsinki,
     diff_months_ceil,
     diff_months_floor,
@@ -15,6 +18,20 @@ from parking_permits.utils import (
     flatten_dict,
     get_model_diff,
 )
+
+
+@pytest.mark.parametrize(
+    "gross_price,vat,net_price,vat_price",
+    [
+        pytest.param(100, 0.24, 80.65, 60.00, id="default"),
+        pytest.param(100, None, 100, 100, id="VAT none"),
+        pytest.param(None, 0.24, 0, 0, id="gross none"),
+    ],
+)
+def test_calc_prices(gross_price, vat, net_price, vat_price):
+    delta = Decimal(1.0)
+    assert calc_net_price(gross_price, vat) == pytest.approx(Decimal(net_price), delta)
+    assert calc_vat_price(gross_price, vat) == pytest.approx(Decimal(vat_price), delta)
 
 
 class DateTimeToHelsinkiTestCase(TestCase):

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -337,6 +337,14 @@ def flatten_dict(d, separator="__", prefix="", _output_ref=None) -> dict:
     return output
 
 
+def calc_net_price(gross_price, vat):
+    return Decimal(gross_price) / Decimal(1 + (vat or 0)) if gross_price else Decimal(0)
+
+
+def calc_vat_price(gross_price, vat):
+    return gross_price - calc_net_price(gross_price, vat) if gross_price else Decimal(0)
+
+
 def round_up(v):
     return (
         "{:0.2f}".format(Decimal(v).quantize(Decimal(".001"), rounding=ROUND_UP))


### PR DESCRIPTION
This refactors the VAT and net price calculations in utility functions, as the same logic is applied for product pricing valuations.

[PV-759](https://helsinkisolutionoffice.atlassian.net/browse/PV-759)

## How Has This Been Tested?

Additional and existing unit tests


[PV-759]: https://helsinkisolutionoffice.atlassian.net/browse/PV-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ