### PR TITLE
Use correct VAT amounts in refund emails

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -506,9 +506,10 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
                 else:
                     # if the product is different or diff price is different,
                     # create a new price change item
-                    price_change_vat = (diff_price * new_product.vat).quantize(
-                        Decimal("0.0001")
-                    )
+                    price_change_vat = calc_vat_price(
+                        diff_price, new_product.vat
+                    ).quantize(Decimal("0.0001"))
+
                     price_change_list.append(
                         {
                             "product": new_product.name,

--- a/parking_permits/models/refund.py
+++ b/parking_permits/models/refund.py
@@ -64,6 +64,6 @@ class Refund(TimestampedModelMixin, UserStampedModelMixin):
 
         Returns zero if no order items.
         """
-        return self.amount * 0.24
-        # vat_percent = self.order.order_items.aggregate(models.Avg("vat"))["vat__avg"]
-        # return calc_vat_price(self.amount, vat_percent)
+        return Decimal(
+            sum([item.total_price_vat for item in self.order.order_items.all()])
+        )

--- a/parking_permits/models/refund.py
+++ b/parking_permits/models/refund.py
@@ -4,9 +4,9 @@ from django.conf import settings
 from django.contrib.gis.db import models
 from django.utils.translation import gettext_lazy as _
 
-from .mixins import TimestampedModelMixin, UserStampedModelMixin
+from parking_permits.utils import calc_vat_price
 
-VAT_PERCENT = Decimal(0.24)
+from .mixins import TimestampedModelMixin, UserStampedModelMixin
 
 
 class RefundStatus(models.TextChoices):
@@ -59,4 +59,11 @@ class Refund(TimestampedModelMixin, UserStampedModelMixin):
 
     @property
     def vat(self):
-        return Decimal(self.amount) * VAT_PERCENT
+        """Calculate the VAT amount.
+        We need to calculate this based on the products of the individual order items.
+
+        Returns zero if no order items.
+        """
+        return self.amount * 0.24
+        # vat_percent = self.order.order_items.aggregate(models.Avg("vat"))["vat__avg"]
+        # return calc_vat_price(self.amount, vat_percent)

--- a/parking_permits/models/refund.py
+++ b/parking_permits/models/refund.py
@@ -8,6 +8,8 @@ from parking_permits.utils import calc_vat_price
 
 from .mixins import TimestampedModelMixin, UserStampedModelMixin
 
+VAT_PERCENT = Decimal(0.24)
+
 
 class RefundStatus(models.TextChoices):
     OPEN = "OPEN", _("Open")
@@ -50,6 +52,10 @@ class Refund(TimestampedModelMixin, UserStampedModelMixin):
         blank=True,
     )
 
+    # this is hard coded at the moment. At some point should be
+    # a field we can calculate when the refund is generated.
+    vat_percent = VAT_PERCENT
+
     class Meta:
         verbose_name = _("Refund")
         verbose_name_plural = _("Refunds")
@@ -60,10 +66,7 @@ class Refund(TimestampedModelMixin, UserStampedModelMixin):
     @property
     def vat(self):
         """Calculate the VAT amount.
-        We need to calculate this based on the products of the individual order items.
-
-        Returns zero if no order items.
+        The VAT amount is hard coded here because we do not know the % of individual
+        unused items in this model. In future this should probably be stored as a separate field.
         """
-        return Decimal(
-            sum([item.total_price_vat for item in self.order.order_items.all()])
-        )
+        return calc_vat_price(self.amount, self.vat_percent)

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -543,7 +543,7 @@ class ParkingZoneTestCase(TestCase):
                 self.assertEqual(price_change_list[0]["new_price"], Decimal("15"))
                 self.assertEqual(price_change_list[0]["price_change"], Decimal("-5"))
                 self.assertEqual(
-                    price_change_list[0]["price_change_vat"], Decimal("-1.2")
+                    price_change_list[0]["price_change_vat"], Decimal("-0.9677")
                 )
                 self.assertEqual(price_change_list[0]["month_count"], 2)
                 self.assertEqual(price_change_list[0]["start_date"], date(2021, 5, 1))
@@ -555,7 +555,7 @@ class ParkingZoneTestCase(TestCase):
                 self.assertEqual(price_change_list[1]["new_price"], Decimal("20"))
                 self.assertEqual(price_change_list[1]["price_change"], Decimal("-10"))
                 self.assertEqual(
-                    price_change_list[1]["price_change_vat"], Decimal("-2.4")
+                    price_change_list[1]["price_change_vat"], Decimal("-1.9355")
                 )
                 self.assertEqual(price_change_list[1]["month_count"], 6)
                 self.assertEqual(price_change_list[1]["start_date"], date(2021, 7, 1))
@@ -611,7 +611,7 @@ class ParkingZoneTestCase(TestCase):
                 self.assertEqual(price_change_list[0]["new_price"], Decimal("30"))
                 self.assertEqual(price_change_list[0]["price_change"], Decimal("20"))
                 self.assertEqual(
-                    price_change_list[0]["price_change_vat"], Decimal("4.8")
+                    price_change_list[0]["price_change_vat"], Decimal("3.8710")
                 )
                 self.assertEqual(price_change_list[0]["month_count"], 2)
                 self.assertEqual(
@@ -626,7 +626,9 @@ class ParkingZoneTestCase(TestCase):
                 self.assertEqual(price_change_list[1]["previous_price"], Decimal("15"))
                 self.assertEqual(price_change_list[1]["new_price"], Decimal("40"))
                 self.assertEqual(price_change_list[1]["price_change"], Decimal("25"))
-                self.assertEqual(price_change_list[1]["price_change_vat"], Decimal("6"))
+                self.assertEqual(
+                    price_change_list[1]["price_change_vat"], Decimal("4.8387")
+                )
                 self.assertEqual(price_change_list[1]["month_count"], 6)
                 self.assertEqual(
                     price_change_list[1]["start_date"], date(CURRENT_YEAR, 7, 1)

--- a/parking_permits/tests/models/test_refund.py
+++ b/parking_permits/tests/models/test_refund.py
@@ -2,21 +2,15 @@ from decimal import Decimal
 
 from django.test import TestCase
 
-from parking_permits.tests.factories.order import OrderFactory, OrderItemFactory
 from parking_permits.tests.factories.refund import RefundFactory
 
 
 class TestRefund(TestCase):
-    def test_vat_no_order_items(self):
-        refund = RefundFactory()
+    def test_vat_zero_amount(self):
+        refund = RefundFactory(amount=0)
         assert refund.vat == Decimal(0)
 
-    def test_vat_with_different_rates(self):
-        order = OrderFactory()
+    def test_vat(self):
+        refund = RefundFactory(amount=100)
 
-        OrderItemFactory(unit_price=10, vat=0.24, order=order, quantity=2)
-        OrderItemFactory(unit_price=10, vat=0.20, order=order, quantity=1)
-
-        refund = RefundFactory(order=order, amount=200)
-
-        self.assertAlmostEqual(refund.vat, Decimal(5.53), delta=Decimal("0.01"))
+        self.assertAlmostEqual(refund.vat, Decimal(19.35), delta=Decimal("0.01"))

--- a/parking_permits/tests/models/test_refund.py
+++ b/parking_permits/tests/models/test_refund.py
@@ -1,0 +1,22 @@
+from decimal import Decimal
+
+from django.test import TestCase
+
+from parking_permits.tests.factories.order import OrderFactory, OrderItemFactory
+from parking_permits.tests.factories.refund import RefundFactory
+
+
+class TestRefund(TestCase):
+    def test_vat_no_order_items(self):
+        refund = RefundFactory()
+        assert refund.vat == Decimal(0)
+
+    def test_vat_with_different_rates(self):
+        order = OrderFactory()
+
+        OrderItemFactory(unit_price=10, vat=0.24, order=order, quantity=2)
+        OrderItemFactory(unit_price=10, vat=0.20, order=order, quantity=1)
+
+        refund = RefundFactory(order=order, amount=200)
+
+        self.assertAlmostEqual(refund.vat, Decimal(5.53), delta=Decimal("0.01"))

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -4,18 +4,20 @@ import zoneinfo
 from collections import OrderedDict
 from collections.abc import Callable
 from datetime import datetime
-from decimal import ROUND_UP, Decimal
+from decimal import Decimal
 from itertools import chain
+from typing import Optional, Union
 
 from ariadne import convert_camel_case_to_snake
 from dateutil.relativedelta import relativedelta
-from django.conf import settings
 from django.db import models
 from django.utils import timezone as tz
 from graphql import GraphQLResolveInfo
 from pytz import utc
 
 HELSINKI_TZ = zoneinfo.ZoneInfo("Europe/Helsinki")
+
+Currency = Optional[Union[str, float, Decimal]]
 
 
 class DefaultOrderedDict(OrderedDict):
@@ -337,12 +339,40 @@ def flatten_dict(d, separator="__", prefix="", _output_ref=None) -> dict:
     return output
 
 
-def calc_net_price(gross_price, vat):
-    return Decimal(gross_price) / Decimal(1 + (vat or 0)) if gross_price else Decimal(0)
+def calc_net_price(gross_price: Currency, vat: Currency) -> Decimal:
+    """Returns the net price based on the gross and VAT e.g. 0.24
+
+    Net price is calculated thus:
+
+        gross / (1 + vat)
+
+    For example, gross 100 EUR, VAT 24% would be:
+
+        100 / 1.24 = ~80.64
+
+    If gross or vat is zero or None, returns zero.
+    """
+    return (
+        Decimal(gross_price) / Decimal(1 + (Decimal(vat or 0)))
+        if gross_price and vat
+        else Decimal(0)
+    )
 
 
-def calc_vat_price(gross_price, vat):
-    return gross_price - calc_net_price(gross_price, vat) if gross_price else Decimal(0)
+def calc_vat_price(gross_price: Currency, vat: Currency) -> Decimal:
+    """Returns the VAT price based on the gross and VAT e.g. 0.24
+
+    VAT price is equal to the gross minus the net.
+
+    For example, gross 100 EUR, VAT 24% would be net price of ~80.64.
+
+    VAT price would therefore be 100-80.64 = 19.36.
+    """
+    return (
+        Decimal(gross_price) - calc_net_price(gross_price, vat)
+        if gross_price and vat
+        else Decimal(0)
+    )
 
 
 def round_up(v):

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -4,12 +4,13 @@ import zoneinfo
 from collections import OrderedDict
 from collections.abc import Callable
 from datetime import datetime
-from decimal import Decimal
+from decimal import ROUND_UP, Decimal
 from itertools import chain
 from typing import Optional, Union
 
 from ariadne import convert_camel_case_to_snake
 from dateutil.relativedelta import relativedelta
+from django.conf import settings
 from django.db import models
 from django.utils import timezone as tz
 from graphql import GraphQLResolveInfo


### PR DESCRIPTION


## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-763](https://helsinkisolutionoffice.atlassian.net/browse/PV-763)

## How Has This Been Tested?

Manually + unit tests

## Manual Testing Instructions for Reviewers

Create a refund in Webshop, check that the correct amounts are sent in email (or command line in local development)



[PV-763]: https://helsinkisolutionoffice.atlassian.net/browse/PV-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ