### PR TITLE
Use localtime explicitly when checking permit statuses

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -183,7 +183,7 @@ class CustomerPermit:
                     permit.latest_order.talpa_last_valid_purchase_time
                     + tz.timedelta(minutes=payment_wait_time)
                 )
-                < tz.now()
+                < tz.localtime(tz.now())
             ):
                 permit.status = DRAFT
                 permit.save()


### PR DESCRIPTION
## Description

Use localtime explicitly when checking permit statuses

## Context

[PV-772](https://helsinkisolutionoffice.atlassian.net/browse/PV-772)

## How Has This Been Tested?

Manually.


[PV-772]: https://helsinkisolutionoffice.atlassian.net/browse/PV-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ