### PR TITLE
Ensure any single quotes in the address passed to WSF are escaped

### DIFF
--- a/parking_permits/services/kami.py
+++ b/parking_permits/services/kami.py
@@ -20,8 +20,11 @@ def get_wfs_result(street_name="", street_number_token=""):
     street_number = (
         int(street_number_first_part.group()) if street_number_first_part else 0
     )
-    # escape single quotes
-    street_name = street_name.replace("'", r"&#39")
+
+    # escape single quotes: we need to use 4x the quote because the
+    # value is inside double quotes
+    # see https://docs.geoserver.org/main/en/user/filter/ecql_reference.html#filter-ecql-reference
+    street_name = street_name.replace("'", "''''")
 
     street_address = f"katunimi=''{street_name}'' AND osoitenumero=''{street_number}''"
     query_single_args = [
@@ -30,6 +33,7 @@ def get_wfs_result(street_name="", street_number_token=""):
         f"'{street_address}'",
     ]
     cql_filter = f"CONTAINS(geom,querySingle({','.join(query_single_args)}))"
+
     type_names = [
         "avoindata:Asukas_ja_yrityspysakointivyohykkeet_alue",
         "avoindata:Helsinki_osoiteluettelo",


### PR DESCRIPTION

## Context

[PV-773](https://helsinkisolutionoffice.atlassian.net/browse/PV-773)

## How Has This Been Tested?

In Django shell:

```python
address = "Tarkk'ampujankatu"
street_number = "14 B 42"

from parking_permit.services.kami import get_wfs_result

resp = get_wfs_result(address, street_number)

```

[PV-773]: https://helsinkisolutionoffice.atlassian.net/browse/PV-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ