### PR TITLE
Update resolve-product endpoint to always send also modified order item metadata

### DIFF
--- a/parking_permits/talpa/order.py
+++ b/parking_permits/talpa/order.py
@@ -158,8 +158,9 @@ class TalpaOrderManager:
                     order_items_of_single_permit.append(item)
 
             # Append details of permit only to the last order item of permit.
-            cls.append_detail_meta(order_items_of_single_permit[-1], permit)
-            items += order_items_of_single_permit
+            if len(order_items_of_single_permit) > 0:
+                cls.append_detail_meta(order_items_of_single_permit[-1], permit)
+                items += order_items_of_single_permit
 
         customer = cls.create_customer_data(order.customer)
         last_valid_purchase_date_time = (

--- a/parking_permits/tests/services/test_talpa.py
+++ b/parking_permits/tests/services/test_talpa.py
@@ -24,7 +24,7 @@ class TestTalpaOrderManager(TestCase):
             vat=Decimal(0.24),
         )
 
-        data = TalpaOrderManager._create_order_data(order_item.order)
+        data = TalpaOrderManager.create_order_data(order_item.order)
         self.assertEqual(data["priceNet"], "193.55")
         self.assertEqual(data["priceVat"], "46.45")
         self.assertEqual(data["priceTotal"], "240.00")
@@ -37,7 +37,7 @@ class TestTalpaOrderManager(TestCase):
             vat=Decimal(0.24),
         )
 
-        data = TalpaOrderManager._create_item_data(order_item.order, order_item)
+        data = TalpaOrderManager.create_item_data(order_item.order, order_item)
 
         self.assertEqual(data["priceNet"], "24.19")
         self.assertEqual(data["priceVat"], "5.81")

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -76,6 +76,7 @@ from .services.mail import (
     send_permit_email,
     send_vehicle_low_emission_discount_email,
 )
+from .talpa.order import TalpaOrderManager
 from .utils import (
     get_end_time,
     get_meta_item,
@@ -226,6 +227,24 @@ class TalpaResolveProduct(APIView):
             product = product_with_quantity[0]
             if not product:
                 return bad_request_response("Product not found")
+
+            order_item_response_data = {"meta": []}
+            order_item = permit.order_items.first()
+            if order_item:
+                order_item_response_data.get("meta").append(
+                    {
+                        "key": "sourceOrderItemId",
+                        "value": str(order_item.id),
+                        "visibleInCheckout": False,
+                        "ordinal": 0,
+                    },
+                )
+                TalpaOrderManager.append_detail_meta(
+                    order_item_response_data,
+                    permit,
+                    fixed_end_time=permit.end_time + relativedelta(months=1),
+                )
+
             response = snake_to_camel_dict(
                 {
                     "subscription_id": subscription_id,
@@ -233,6 +252,7 @@ class TalpaResolveProduct(APIView):
                     "product_id": str(product.talpa_product_id),
                     "product_name": product.name,
                     "product_label": permit.vehicle.description,
+                    "order_item_metas": order_item_response_data.get("meta"),
                 }
             )
         except Exception as e:


### PR DESCRIPTION
## Description

Update resolve-product endpoint to always send also modified order item metadata back to Talpa.
Update resolve-product tests.

## Context

[PV-705](https://helsinkisolutionoffice.atlassian.net/browse/PV-705)

## How Has This Been Tested?

Through unit-tests.


[PV-705]: https://helsinkisolutionoffice.atlassian.net/browse/PV-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ