### PR TITLE
Log closed permit id on expiration of permits

### DIFF
--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -39,6 +39,7 @@ def automatic_expiration_of_permits():
             active_permit = active_permits.first()
             active_permit.primary_vehicle = True
             active_permit.save()
+        logger.info(f"Permit {permit.pk} ended")
 
     logger.info("Automatically ending permits completed.")
 


### PR DESCRIPTION
## Description

Log closed permit id on expiration of permits.

## Context

[PV-778](https://helsinkisolutionoffice.atlassian.net/browse/PV-778)

## How Has This Been Tested?

Manually by running the cronjob.

[PV-778]: https://helsinkisolutionoffice.atlassian.net/browse/PV-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ