### PR TITLE
Use only vehicle own weight as weight limit

### DIFF
--- a/parking_permits/services/traficom.py
+++ b/parking_permits/services/traficom.py
@@ -149,10 +149,11 @@ class Traficom:
                     emission_type = EmissionType.WLTP
 
         mass = et.find(".//massa")
-        module_weight = mass.find("modulinKokonaismassa")
-        technical_weight = mass.find("teknSuurSallKokmassa")
-        weight_et = module_weight if module_weight is not None else technical_weight
-        weight = safe_cast(weight_et.text, int, 0) if weight_et.text else 0
+        weight_et = mass.find("omamassa")
+        try:
+            weight = safe_cast(weight_et.text, int, 0)
+        except AttributeError:
+            weight = 0
         if weight and weight >= VEHICLE_MAX_WEIGHT_KG:
             raise TraficomFetchVehicleError(
                 _(


### PR DESCRIPTION
## Description

Use only vehicle own weight as weight limit.

## Context

[PV-783](https://helsinkisolutionoffice.atlassian.net/browse/PV-783)

## How Has This Been Tested?

Through unit-tests.

[PV-783]: https://helsinkisolutionoffice.atlassian.net/browse/PV-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ