### PR TITLE
Permit can be ended if current period end time same day or less than

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -341,8 +341,14 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
     @property
     def can_end_after_current_period(self):
-        return self.is_valid and (
-            self.end_time is None or self.current_period_end_time < self.end_time
+        if not self.is_valid:
+            return False
+
+        if self.end_time is None:
+            return False
+
+        return timezone.localdate(self.current_period_end_time) <= timezone.localdate(
+            self.end_time
         )
 
     @property


### PR DESCRIPTION


## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-786](https://helsinkisolutionoffice.atlassian.net/browse/PV-786)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

Unit tests

## Manual Testing Instructions for Reviewers

In Webshop, create a new open ended permit. When cancelling the permit, you should have both options available ("immediate", or "end of current period"). In both cases the permit should be closed correctly or the end date set to end at specified time.

<!-- Add screenshots if appropriate -->
