### PR TITLE
Send announcements only to valid permits

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -1316,7 +1316,10 @@ def resolve_announcement(obj, info, announcement_id):
 
 def post_create_announcement(announcement: Announcement):
     customer_ids = (
-        ParkingPermit.objects.filter(parking_zone__in=announcement.parking_zones)
+        ParkingPermit.objects.filter(
+            parking_zone__in=announcement.parking_zones,
+            status=ParkingPermitStatus.VALID,
+        )
         .values_list("customer_id", flat=True)
         .order_by("customer")
         .distinct()


### PR DESCRIPTION
## Description

Send announcements only to valid permits

## Context

[PV-764](https://helsinkisolutionoffice.atlassian.net/browse/PV-764)

## How Has This Been Tested?

Manually.

[PV-764]: https://helsinkisolutionoffice.atlassian.net/browse/PV-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ