### PR TITLE
Update Talpa order cancellation conditions

### DIFF
--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -1064,8 +1064,50 @@ class OrderViewTestCase(APITestCase):
         self.assertEqual(response.status_code, 200)
         order.refresh_from_db()
         permit.refresh_from_db()
+        # Order and permit statuses should change to cancelled
         self.assertEqual(order.status, OrderStatus.CANCELLED)
         self.assertEqual(permit.status, ParkingPermitStatus.CANCELLED)
+
+    def test_order_cancellation_for_closed_permit(self):
+        talpa_existing_order_id = "d86ca61d-97e9-410a-a1e3-4894873b1b35"
+        customer = CustomerFactory()
+        permit_start_time = datetime.datetime(
+            2024, 2, 8, 10, 00, 0, tzinfo=datetime.timezone.utc
+        )
+        permit_end_time = datetime.datetime(
+            2024, 3, 7, 23, 59, 0, tzinfo=datetime.timezone.utc
+        )
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.CLOSED,
+            customer=customer,
+            start_time=permit_start_time,
+            end_time=permit_end_time,
+        )
+        order = OrderFactory(
+            talpa_order_id=talpa_existing_order_id,
+            customer=customer,
+            status=OrderStatus.CONFIRMED,
+            paid_time=tz.make_aware(
+                datetime.datetime.strptime(
+                    "2024-02-08T10:00:00.000Z", "%Y-%m-%dT%H:%M:%S.%fZ"
+                )
+            ),
+        )
+        order.permits.add(permit)
+        order.save()
+
+        url = reverse("parking_permits:order-notify")
+        data = {
+            "eventType": "ORDER_CANCELLED",
+            "orderId": talpa_existing_order_id,
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        order.refresh_from_db()
+        permit.refresh_from_db()
+        # Order and permit statuses should not change
+        self.assertEqual(order.status, OrderStatus.CONFIRMED)
+        self.assertEqual(permit.status, ParkingPermitStatus.CLOSED)
 
     @override_settings(DEBUG=True)
     @patch.object(OrderValidator, "validate_order")


### PR DESCRIPTION
## Description

Update permit and order to CANCELLED-state only when permit is in DRAFT-, PAYMENT_IN_PROGRESS- or VALID-state.

## Context

[PV-789](https://helsinkisolutionoffice.atlassian.net/browse/PV-789)

## How Has This Been Tested?

Through unit-tests


[PV-789]: https://helsinkisolutionoffice.atlassian.net/browse/PV-789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ