### PR TITLE
Temporarily disable vehicle user check

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -151,22 +151,23 @@ class CustomerPermit:
             permit.temporary_vehicles.filter(end_time__lt=tz.now()).update(
                 is_active=False
             )
-            vehicle = permit.vehicle
+            # vehicle = permit.vehicle
             # Update vehicle detail from traficom if it wasn't updated today
-            if (
-                not permit.vehicle.updated_from_traficom_on
-                or permit.vehicle.updated_from_traficom_on < tz.localdate(tz.now())
-            ):
-                vehicle = self.customer.fetch_vehicle_detail(
-                    vehicle.registration_number,
-                    permit=permit,
-                )
+            # if (
+            #    not permit.vehicle.updated_from_traficom_on
+            #    or permit.vehicle.updated_from_traficom_on < tz.localdate(tz.now())
+            # ):
+            #    vehicle = self.customer.fetch_vehicle_detail(
+            #        vehicle.registration_number,
+            #        permit=permit,
+            #    )
 
-            user_of_vehicle = self.customer.is_user_of_vehicle(vehicle)
-            if not user_of_vehicle:
-                permit.vehicle_changed = True
-                permit.vehicle_changed_date = tz.localdate(tz.now())
-                permit.save()
+            # Temporarily disable vehicle user check
+            # user_of_vehicle = self.customer.is_user_of_vehicle(vehicle)
+            # if not user_of_vehicle:
+            #    permit.vehicle_changed = True
+            #    permit.vehicle_changed_date = tz.localdate(tz.now())
+            #    permit.save()
             products = []
             for product_with_qty in permit.get_products_with_quantities():
                 product = self._calculate_prices(permit, product_with_qty)

--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -4,6 +4,7 @@ from datetime import timezone as dt_tz
 from decimal import Decimal
 from unittest.mock import patch
 
+import pytest
 import requests_mock
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -761,6 +762,9 @@ class ResolveRightOfPurchaseViewTestCase(APITestCase):
             "ParkingPermit matching query does not exist.",
         )
 
+    @pytest.mark.skip(
+        reason="Temporary skip Traficom checks until vehicle user data is quaranteed to be available always"
+    )
     @override_settings(
         DEBUG=True,
         TRAFICOM_CHECK=False,

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -379,29 +379,30 @@ class TalpaResolveRightOfPurchase(APIView):
             return bad_request_response("User id is missing from request data")
 
         try:
-            permit = ParkingPermit.objects.get(pk=permit_id)
-            customer = permit.customer
-            if settings.TRAFICOM_CHECK:
-                customer.fetch_driving_licence_detail(permit)
-                is_driving_licence_active = customer.driving_licence.active
-            else:
-                is_driving_licence_active = True
-            vehicle = customer.fetch_vehicle_detail(
-                permit.vehicle.registration_number, permit
-            )
-            is_user_of_vehicle = customer.is_user_of_vehicle(vehicle)
-            has_valid_driving_licence = customer.has_valid_driving_licence_for_vehicle(
-                vehicle
-            )
+            # Temporarily disabled traficom checks
+            permit = ParkingPermit.objects.get(pk=permit_id)  # noqa: F841
+            # customer = permit.customer
+            # if settings.TRAFICOM_CHECK:
+            #    customer.fetch_driving_licence_detail(permit)
+            #    is_driving_licence_active = customer.driving_licence.active
+            # else:
+            #     is_driving_licence_active = True
+            # vehicle = customer.fetch_vehicle_detail(
+            #     permit.vehicle.registration_number, permit
+            # )
+            # is_user_of_vehicle = customer.is_user_of_vehicle(vehicle)
+            # has_valid_driving_licence = customer.has_valid_driving_licence_for_vehicle(
+            #     vehicle
+            # )
             order_item = OrderItem.objects.get(talpa_order_item_id=order_item_id)
             is_valid_subscription = (
                 order_item.subscription.status == SubscriptionStatus.CONFIRMED
             )
             right_of_purchase = (
                 is_valid_subscription
-                and is_user_of_vehicle
-                and is_driving_licence_active
-                and has_valid_driving_licence
+                # and is_user_of_vehicle
+                # and is_driving_licence_active
+                # and has_valid_driving_licence
             )
             res = snake_to_camel_dict(
                 {


### PR DESCRIPTION
## Description

Vehicle user might not be set in Admin UI in all scenarios, when creating or updating the permits. Needs to be checked more closely before re-enabling this check.
