### PR TITLE
Validate order only when orderId and userId exists

### DIFF
--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -599,6 +599,10 @@ class OrderView(APIView):
             order_item = subscription.order_items.first()
             permit = order_item.permit
 
+            if not permit or not permit.customer or not permit.customer.user:
+                return bad_request_response(
+                    f"Permit {permit} or customer {permit.customer} or user {permit.customer.user} is missing"
+                )
             try:
                 validated_order_data = OrderValidator.validate_order(
                     talpa_order_id, permit.customer.user.uuid
@@ -715,6 +719,10 @@ class SubscriptionView(APIView):
             order = Order.objects.get(talpa_order_id=talpa_order_id)
         except Order.DoesNotExist:
             return not_found_response(f"Order {talpa_order_id} does not exist")
+        if not order.customer or not order.customer.user:
+            return bad_request_response(
+                f"Order {talpa_order_id} customer or user is missing"
+            )
         try:
             OrderValidator.validate_order(talpa_order_id, order.customer.user.uuid)
         except OrderValidationError as e:


### PR DESCRIPTION
## Description

Validate order only when orderId and userId exists.
Also add extra validation to Talpa webhooks.

## Context

[PV-797](https://helsinkisolutionoffice.atlassian.net/browse/PV-797)

## How Has This Been Tested?

Through unit-tests.


[PV-797]: https://helsinkisolutionoffice.atlassian.net/browse/PV-797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ