### PR TITLE
Enforce upper case for all manually entered national ID numbers.

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -308,7 +308,9 @@ def resolve_customers(obj, info, page_input, order_by=None, search_params=None):
     autotarget=audit.TARGET_RETURN,
 )
 def resolve_vehicle(obj, info, reg_number, national_id_number):
-    customer = Customer.objects.get_or_create(national_id_number=national_id_number)[0]
+    customer = Customer.objects.get_or_create(
+        national_id_number=national_id_number.upper()
+    )[0]
     if settings.TRAFICOM_CHECK:
         customer.fetch_driving_licence_detail()
     vehicle = customer.fetch_vehicle_detail(reg_number)
@@ -357,7 +359,6 @@ def update_or_create_customer(customer_info):
     customer_data = {
         "first_name": customer_info.get("first_name", ""),
         "last_name": customer_info.get("last_name", ""),
-        "national_id_number": customer_info["national_id_number"],
         "email": customer_info["email"],
         "phone_number": customer_info["phone_number"],
         "address_security_ban": customer_info["address_security_ban"],
@@ -392,8 +393,10 @@ def update_or_create_customer(customer_info):
             "other_address_apartment"
         )
 
+    national_id_number = customer_info["national_id_number"].upper()
+
     return Customer.objects.update_or_create(
-        national_id_number=customer_info["national_id_number"], defaults=customer_data
+        national_id_number=national_id_number, defaults=customer_data
     )[0]
 
 


### PR DESCRIPTION
Also added unit tests for update or create new customer.


## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-785](https://helsinkisolutionoffice.atlassian.net/browse/PV-785)

## How Has This Been Tested?

Unit tests and manual testing

## Manual Testing Instructions for Reviewers

In admin UI, try adding a new customer hetu in lower case e.g.` 290200a905h`.

When saved to the database, the hetu should be automatically be in upper case e.g. `290200A905H`.

**Note**: the correct way to handle this would be to enforce case-insensitive uniqueness at database level with a `UniqueConstraint` on the model using `Upper()` database function rather than `unique=True`. This would ensure for example all customer IDs from DVV will be handled correctly. However as we have such duplicates already in production, this will require some manual cleanup first from the administrators. This change however should prevent new duplicates being created in the admin UI.


## Screenshots

<!-- Add screenshots if appropriate -->


[PV-785]: https://helsinkisolutionoffice.atlassian.net/browse/PV-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ