### PR TITLE
Permit active temporary vehicle should be None if current time outside

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -284,7 +284,10 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
     @property
     def active_temporary_vehicle(self):
-        return self.temporary_vehicles.filter(is_active=True).first()
+        now = timezone.now()
+        return self.temporary_vehicles.filter(
+            is_active=True, start_time__lte=now, end_time__gte=now
+        ).first()
 
     @property
     def consent_low_emission_accepted(self):

--- a/parking_permits/tests/factories/vehicle.py
+++ b/parking_permits/tests/factories/vehicle.py
@@ -56,7 +56,7 @@ class LowEmissionCriteriaFactory(factory.django.DjangoModelFactory):
 
 
 class TemporaryVehicleFactory(factory.django.DjangoModelFactory):
-    vehicle = factory.SubFactory(Vehicle)
+    vehicle = factory.SubFactory(VehicleFactory)
     start_time = factory.LazyFunction(
         lambda: fake.date_time_between(
             start_date="-2d", end_date="-1d", tzinfo=pytz.utc


### PR DESCRIPTION
Active temporary vehicle only appears if the vehicle is within the specified time range.

## Description

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-666](https://helsinkisolutionoffice.atlassian.net/browse/PV-666)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[PV-666]: https://helsinkisolutionoffice.atlassian.net/browse/PV-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ