### PR TITLE
Send permit expiration email only for fixed-period permits

### DIFF
--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -9,6 +9,7 @@ from parking_permits.exceptions import ParkkihubiPermitError
 from parking_permits.models import Customer, ParkingPermit
 from parking_permits.models.order import SubscriptionCancelReason
 from parking_permits.models.parking_permit import (
+    ContractType,
     ParkingPermitEndType,
     ParkingPermitStatus,
 )
@@ -51,7 +52,9 @@ def automatic_expiration_remind_notification_of_permits():
     count = 0
     now = tz.localdate(tz.now())
     expiring_permits = ParkingPermit.objects.filter(
-        end_time__lt=now + relativedelta(weeks=1), status=ParkingPermitStatus.VALID
+        end_time__lt=now + relativedelta(weeks=1),
+        status=ParkingPermitStatus.VALID,
+        contract_type=ContractType.FIXED_PERIOD,
     )
     for permit in expiring_permits:
         success = send_permit_email(PermitEmailType.EXPIRATION_REMIND, permit)

--- a/parking_permits/tests/test_cron.py
+++ b/parking_permits/tests/test_cron.py
@@ -12,7 +12,11 @@ from parking_permits.cron import (
     automatic_remove_obsolete_customer_data,
 )
 from parking_permits.models import Customer
-from parking_permits.models.parking_permit import ParkingPermit, ParkingPermitStatus
+from parking_permits.models.parking_permit import (
+    ContractType,
+    ParkingPermit,
+    ParkingPermitStatus,
+)
 from parking_permits.tests.factories.customer import CustomerFactory
 from parking_permits.tests.factories.parking_permit import ParkingPermitFactory
 
@@ -179,26 +183,43 @@ class AutomaticExpirationRemindPermitNotificationTestCase(TestCase):
             customer=self.customer,
             end_time=datetime(2023, 3, 31, tzinfo=dt_tz.utc),
             status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.FIXED_PERIOD,
         )
         ParkingPermitFactory(
             customer=self.customer,
             end_time=datetime(2023, 4, 6, tzinfo=dt_tz.utc),
             status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.FIXED_PERIOD,
         )
         ParkingPermitFactory(
             customer=self.customer,
             end_time=datetime(2023, 3, 30, tzinfo=dt_tz.utc),
             status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.FIXED_PERIOD,
         )
         ParkingPermitFactory(
             customer=self.customer,
             end_time=datetime(2023, 4, 13, tzinfo=dt_tz.utc),
             status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.FIXED_PERIOD,
+        )
+        ParkingPermitFactory(
+            customer=self.customer,
+            end_time=datetime(2023, 4, 12, tzinfo=dt_tz.utc),
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
         )
         ParkingPermitFactory(
             customer=self.customer,
             end_time=datetime(2023, 3, 31, tzinfo=dt_tz.utc),
             status=ParkingPermitStatus.CLOSED,
+            contract_type=ContractType.FIXED_PERIOD,
+        )
+        ParkingPermitFactory(
+            customer=self.customer,
+            end_time=datetime(2023, 3, 31, tzinfo=dt_tz.utc),
+            status=ParkingPermitStatus.CLOSED,
+            contract_type=ContractType.OPEN_ENDED,
         )
 
     @freeze_time(tz.make_aware(datetime(2023, 3, 30)))
@@ -206,6 +227,6 @@ class AutomaticExpirationRemindPermitNotificationTestCase(TestCase):
     def test_automatic_expiration_remind_targets(self, mock_method):
         mock_method.return_value = None
         valid_permits = ParkingPermit.objects.filter(status=ParkingPermitStatus.VALID)
-        self.assertEqual(valid_permits.count(), 4)
+        self.assertEqual(valid_permits.count(), 5)
         expiring_permits = automatic_expiration_remind_notification_of_permits()
         self.assertEqual(expiring_permits.count(), 2)


### PR DESCRIPTION
## Description

At the moment permit expiration emails do not take permit contract-type into account.
Send permit expiration email only for fixed-period permits.

## Context

[PV-809](https://helsinkisolutionoffice.atlassian.net/browse/PV-809)

## How Has This Been Tested?

Through updated unit tests.


[PV-809]: https://helsinkisolutionoffice.atlassian.net/browse/PV-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ