### PR TITLE
Allow start and end times for temp vehicles before current time. 

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -28,7 +28,6 @@ from .models import (
     ParkingPermit,
     Refund,
     Subscription,
-    TemporaryVehicle,
     Vehicle,
 )
 from .models.order import (
@@ -127,32 +126,13 @@ class CustomerPermit:
         permit_details = self._get_permit(permit_id)
         permit = permit_details[0]
 
-        if tz.localtime(isoparse(start_time)) < permit.start_time:
-            raise TemporaryVehicleValidationError(
-                _("Temporary vehicle start time has to be after permit start time")
-            )
-
-        tmp_vehicles = permit.temp_vehicles.filter(
-            start_time__gte=get_end_time(tz.now(), -12)
-        ).order_by("-start_time")[:2]
-
-        if tmp_vehicles.count() == 2:
-            raise TemporaryVehicleValidationError(
-                _(
-                    "Can not have more than 2 temporary vehicles in 365 days from first one."
-                )
-            )
-
-        vehicle = TemporaryVehicle.objects.create(
-            vehicle=Vehicle.objects.get(registration_number__iexact=registration),
-            end_time=end_time,
-            start_time=start_time,
+        permit.add_temporary_vehicle(
+            self.customer.user,
+            Vehicle.objects.get(registration_number__iexact=registration),
+            *permit.parse_temporary_vehicle_times(start_time, end_time),
+            check_limit=True,
         )
-        permit.temp_vehicles.add(vehicle)
-        ParkingPermitEventFactory.make_add_temporary_vehicle_event(
-            permit, vehicle, created_by=self.customer.user
-        )
-        permit.update_parkkihubi_permit()
+
         send_permit_email(PermitEmailType.TEMP_VEHICLE_ACTIVATED, permit)
         return True
 

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -2,9 +2,12 @@ import itertools
 import json
 import logging
 import operator
+from datetime import datetime
 from decimal import Decimal
+from typing import Tuple
 
 import requests
+from dateutil.parser import isoparse
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -18,7 +21,11 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import gettext_noop
 from helsinki_gdpr.models import SerializableMixin
 
-from ..exceptions import ParkkihubiPermitError, PermitCanNotBeEnded
+from ..exceptions import (
+    ParkkihubiPermitError,
+    PermitCanNotBeEnded,
+    TemporaryVehicleValidationError,
+)
 from ..utils import (
     calc_net_price,
     calc_vat_price,
@@ -812,6 +819,90 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         for order_item, quantity, date_range in unused_order_items:
             total += order_item.unit_price * quantity
         return total
+
+    def parse_temporary_vehicle_times(
+        self,
+        start_time: str,
+        end_time: str,
+    ) -> Tuple[datetime, datetime]:
+        """Returns start and and end times for a temporary vehicle, checking
+        times against the permit.
+
+        Parses input strings. If start time less than current time, should be same as
+        current time. If end time less than start time + 1 hour, should be start time + 1 hour.
+
+        Start and end times should be returned in local time zone.
+
+        If start time is less than the permit start time, will raise a TemporaryVehicleValidationError.
+        """
+
+        now = timezone.localtime()
+
+        start_dt = max(timezone.localtime(isoparse(start_time)), now)
+
+        if start_dt < timezone.localtime(self.start_time):
+            raise TemporaryVehicleValidationError(
+                _("Temporary vehicle start time has to be after permit start time")
+            )
+
+        end_dt = max(
+            timezone.localtime(isoparse(end_time)),
+            start_dt + timezone.timedelta(hours=1),
+        )
+
+        return start_dt, end_dt
+
+    def add_temporary_vehicle(
+        self,
+        user,
+        vehicle,
+        start_time: datetime,
+        end_time: datetime,
+        *,
+        check_limit: bool,
+    ):
+        """Add a new temporary vehicle, creating an event and updating Parkkihubi.
+
+        If `check_limit` is `True` and limit is exceeded, will raise a TemporaryVehicleValidationError.
+
+        """
+        if check_limit and self.is_temporary_vehicle_limit_exceeded():
+            raise TemporaryVehicleValidationError(
+                _(
+                    "Can not have more than 2 temporary vehicles in 365 days from first one."
+                )
+            )
+
+        from .temporary_vehicle import TemporaryVehicle
+
+        temp_vehicle = TemporaryVehicle.objects.create(
+            vehicle=vehicle,
+            end_time=end_time,
+            start_time=start_time,
+        )
+
+        self.temp_vehicles.add(temp_vehicle)
+
+        ParkingPermitEventFactory.make_add_temporary_vehicle_event(
+            self, temp_vehicle, user
+        )
+        self.update_parkkihubi_permit()
+
+        return temp_vehicle
+
+    def is_temporary_vehicle_limit_exceeded(self) -> bool:
+        """Check limit of temporary vehicles. A user can only
+        have max 2 temp vehicles over 12 months."""
+        return (
+            len(
+                self.temp_vehicles.filter(
+                    start_time__gte=get_end_time(timezone.now(), -12)
+                )
+                .order_by("-start_time")
+                .values("pk")[:2]
+            )
+            == 2
+        )
 
     def get_unused_order_items(self):
         unused_start_date = timezone.localdate(self.next_period_start_time)

--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -9,9 +9,7 @@ from ariadne import (
     snake_case_fallback_resolvers,
 )
 from ariadne.contrib.federation import FederatedObjectType
-from dateutil.parser import isoparse
 from django.db import transaction
-from django.utils import timezone as tz
 from django.utils.translation import gettext_lazy as _
 
 import audit_logger as audit
@@ -25,7 +23,6 @@ from .exceptions import (
     AddressError,
     ObjectNotFound,
     ParkingZoneError,
-    TemporaryVehicleValidationError,
     TraficomFetchVehicleError,
 )
 from .models import Address, Customer, Refund, Vehicle
@@ -561,8 +558,6 @@ def resolve_add_temporary_vehicle(
     audit_msg.target = audit.ModelWithId(ParkingPermit, permit_id)
     request = info.context["request"]
     customer = request.user.customer
-    if tz.localtime(isoparse(start_time)) < tz.now():
-        raise TemporaryVehicleValidationError(_("Start time cannot be in the past"))
     vehicle = Traficom().fetch_vehicle_details(registration_number=registration)
     has_valid_licence = customer.has_valid_driving_licence_for_vehicle(vehicle)
     if not has_valid_licence:

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -13,12 +13,14 @@ from parking_permits.exceptions import (
     ParkkihubiPermitError,
     PermitCanNotBeEnded,
     ProductCatalogError,
+    TemporaryVehicleValidationError,
 )
 from parking_permits.models import Order, ParkingPermitExtensionRequest
 from parking_permits.models.order import OrderStatus
 from parking_permits.models.parking_permit import (
     ContractType,
     ParkingPermitEndType,
+    ParkingPermitEvent,
     ParkingPermitStatus,
 )
 from parking_permits.models.product import ProductType
@@ -39,6 +41,7 @@ from parking_permits.tests.factories.vehicle import (
 )
 from parking_permits.tests.models.test_product import MockResponse
 from parking_permits.utils import get_end_time
+from users.tests.factories.user import UserFactory
 
 CURRENT_YEAR = date.today().year
 
@@ -1229,3 +1232,239 @@ class ParkingPermitTestCase(TestCase):
             timezone.localtime(permit.end_time).isoformat(),
             "2024-11-12T23:59:59.999999+02:00",
         )
+
+    @freeze_time("2024-3-15 9:00+02:00")
+    @override_settings(TIME_ZONE="Europe/Helsinki")
+    def test_parse_temporary_vehicle_times(self):
+        now = timezone.now()
+
+        start_time = now.isoformat()
+        end_time = (now + timedelta(days=3)).isoformat()
+
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=now - timedelta(days=3),
+            end_time=now + timedelta(days=27),
+            month_count=1,
+        )
+
+        start_dt, end_dt = permit.parse_temporary_vehicle_times(start_time, end_time)
+        self.assertEqual(start_dt.isoformat(), "2024-03-15T09:00:00+02:00")
+        self.assertEqual(end_dt.isoformat(), "2024-03-18T09:00:00+02:00")
+
+    @freeze_time("2024-3-15 9:00+02:00")
+    @override_settings(TIME_ZONE="Europe/Helsinki")
+    def test_parse_temporary_vehicle_times_start_time_before_now(self):
+        now = timezone.now()
+
+        start_time = (now - timedelta(days=3)).isoformat()
+        end_time = (now + timedelta(days=6)).isoformat()
+
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=now - timedelta(days=3),
+            end_time=now + timedelta(days=27),
+            month_count=1,
+        )
+
+        start_dt, end_dt = permit.parse_temporary_vehicle_times(start_time, end_time)
+        self.assertEqual(start_dt.isoformat(), "2024-03-15T09:00:00+02:00")
+        self.assertEqual(end_dt.isoformat(), "2024-03-21T09:00:00+02:00")
+
+    @freeze_time("2024-3-15 9:00+02:00")
+    @override_settings(TIME_ZONE="Europe/Helsinki")
+    def test_parse_temporary_vehicle_times_end_time_less_than_hour(self):
+        now = timezone.now()
+
+        start_time = end_time = now.isoformat()
+
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=now - timedelta(days=3),
+            end_time=now + timedelta(days=27),
+            month_count=1,
+        )
+
+        start_dt, end_dt = permit.parse_temporary_vehicle_times(start_time, end_time)
+        self.assertEqual(start_dt.isoformat(), "2024-03-15T09:00:00+02:00")
+        self.assertEqual(end_dt.isoformat(), "2024-03-15T10:00:00+02:00")
+
+    @freeze_time("2024-3-15 9:00+02:00")
+    @override_settings(TIME_ZONE="Europe/Helsinki")
+    def test_parse_temporary_vehicle_times_start_time_before_permit(self):
+        now = timezone.now()
+
+        start_time = now.isoformat()
+        end_time = (now + timedelta(days=3)).isoformat()
+
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=now + timedelta(days=3),
+            end_time=now + timedelta(days=27),
+            month_count=1,
+        )
+
+        self.assertRaises(
+            TemporaryVehicleValidationError,
+            permit.parse_temporary_vehicle_times,
+            start_time,
+            end_time,
+        )
+
+    @freeze_time("2024-3-15 9:00+02:00")
+    @override_settings(TIME_ZONE="Europe/Helsinki")
+    def test_is_temporary_vehicle_limit_exceeded_true(self):
+        now = timezone.now()
+
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=now - timedelta(days=365),
+            end_time=now + timedelta(days=30),
+            month_count=1,
+        )
+
+        temp_vehicles = TemporaryVehicleFactory.create_batch(
+            2, start_time=now - timedelta(days=30)
+        )
+
+        permit.temp_vehicles.set(temp_vehicles)
+
+        self.assertTrue(permit.is_temporary_vehicle_limit_exceeded())
+
+    @freeze_time("2024-3-15 9:00+02:00")
+    @override_settings(TIME_ZONE="Europe/Helsinki")
+    def test_is_temporary_vehicle_limit_exceeded_false(self):
+        now = timezone.now()
+
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=now - timedelta(days=365),
+            end_time=now + timedelta(days=30),
+            month_count=1,
+        )
+
+        temp_vehicles = TemporaryVehicleFactory.create_batch(
+            1, start_time=now - timedelta(days=30)
+        )
+
+        permit.temp_vehicles.set(temp_vehicles)
+
+        self.assertFalse(permit.is_temporary_vehicle_limit_exceeded())
+
+    @freeze_time("2024-3-15 9:00+02:00")
+    @override_settings(TIME_ZONE="Europe/Helsinki", DEBUG_SKIP_PARKKIHUBI_SYNC=False)
+    @patch("requests.patch", return_value=MockResponse(200))
+    def test_add_temporary_vehicle(self, mock_patch):
+        start_time = now = timezone.now()
+
+        end_time = now + timedelta(days=3)
+
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=now - timedelta(days=3),
+            end_time=now + timedelta(days=27),
+            month_count=1,
+        )
+
+        vehicle = VehicleFactory()
+
+        user = UserFactory()
+
+        self.assertTrue(
+            permit.add_temporary_vehicle(
+                user,
+                vehicle,
+                start_time,
+                end_time,
+                check_limit=True,
+            )
+        )
+
+        self.assertTrue(ParkingPermitEvent.objects.filter(created_by=user).exists())
+
+        mock_patch.assert_called_once()
+
+    @freeze_time("2024-3-15 9:00+02:00")
+    @override_settings(TIME_ZONE="Europe/Helsinki", DEBUG_SKIP_PARKKIHUBI_SYNC=False)
+    @patch("requests.patch", return_value=MockResponse(200))
+    def test_add_temporary_vehicle_limit_exceeded(self, mock_patch):
+        start_time = now = timezone.now()
+        end_time = start_time + timedelta(days=3)
+
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=now - timedelta(days=365),
+            end_time=now + timedelta(days=30),
+            month_count=1,
+        )
+
+        temp_vehicles = TemporaryVehicleFactory.create_batch(
+            2, start_time=now - timedelta(days=30)
+        )
+
+        permit.temp_vehicles.set(temp_vehicles)
+
+        vehicle = VehicleFactory()
+
+        user = UserFactory()
+
+        self.assertRaises(
+            TemporaryVehicleValidationError,
+            permit.add_temporary_vehicle,
+            user,
+            vehicle,
+            start_time,
+            end_time,
+            check_limit=True,
+        )
+
+        self.assertFalse(ParkingPermitEvent.objects.filter(created_by=user).exists())
+
+        mock_patch.assert_not_called()
+
+    @freeze_time("2024-3-15 9:00+02:00")
+    @override_settings(TIME_ZONE="Europe/Helsinki", DEBUG_SKIP_PARKKIHUBI_SYNC=False)
+    @patch("requests.patch", return_value=MockResponse(200))
+    def test_add_temporary_vehicle_limit_exceeded_no_check(self, mock_patch):
+        start_time = now = timezone.now()
+        end_time = start_time + timedelta(days=3)
+
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=now - timedelta(days=365),
+            end_time=now + timedelta(days=30),
+            month_count=1,
+        )
+
+        temp_vehicles = TemporaryVehicleFactory.create_batch(
+            2, start_time=now - timedelta(days=30)
+        )
+
+        permit.temp_vehicles.set(temp_vehicles)
+
+        vehicle = VehicleFactory()
+
+        user = UserFactory()
+
+        self.assertTrue(
+            permit.add_temporary_vehicle(
+                user,
+                vehicle,
+                start_time,
+                end_time,
+                check_limit=False,
+            )
+        )
+
+        self.assertTrue(ParkingPermitEvent.objects.filter(created_by=user).exists())
+
+        mock_patch.assert_called_once()


### PR DESCRIPTION

## Description

<!-- Describe your changes in detail -->

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-665](https://helsinkisolutionoffice.atlassian.net/browse/PV-665)

## How Has This Been Tested?

Unit tests

## Manual Testing Instructions for Reviewers

In webshop and admin UI:

* add a new temp vehicle to a permit
* set start and end time to now

In either case, if the start time is less than now, the start time should be set automatically to current time. The end time should be at least start time plus one hour.

In webshop, you should not be able to create more than 2 temp vehicles every year. This restriction does not apply to the admin.
 

## Screenshots



[PV-665]: https://helsinkisolutionoffice.atlassian.net/browse/PV-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ