### PR TITLE
Add command to find and adjust open ended permits with local time 0:59

### DIFF
--- a/parking_permits/management/commands/fix_dst_renewal_permit_dates.py
+++ b/parking_permits/management/commands/fix_dst_renewal_permit_dates.py
@@ -1,0 +1,30 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.db.models import F
+from django.utils import timezone
+
+from parking_permits.models import ParkingPermit
+from parking_permits.models.parking_permit import ContractType, ParkingPermitStatus
+
+
+class Command(BaseCommand):
+    """
+    Note: this command is run to correct errant open ended permit dates
+    where an extra hour has been assigned due to DST (winter->summer) time changes.
+    """
+
+    help = "Fix DST end dates on open-ended permits."
+
+    def handle(self, *args, **kwargs):
+        # Ensure correct timezone
+        with timezone.override("Europe/Helsinki"):
+            permits = ParkingPermit.objects.filter(
+                status=ParkingPermitStatus.VALID,
+                contract_type=ContractType.OPEN_ENDED,
+                end_time__hour=0,
+                end_time__minute=59,
+            )
+            num_permits = permits.update(end_time=F("end_time") - timedelta(hours=1))
+
+        self.stdout.write(self.style.SUCCESS(f"{num_permits} permit(s) updated"))


### PR DESCRIPTION

## Description

Management command to reset any permits with Helsinki time 00:59 (UTC 21:00) back one hour, to correct for DST.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-806](https://helsinkisolutionoffice.atlassian.net/browse/PV-806)

## How Has This Been Tested?

Tested manually

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[PV-806]: https://helsinkisolutionoffice.atlassian.net/browse/PV-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ