### PR TITLE
Set status_changed_at for extension requests in management command.

### DIFF
--- a/parking_permits/management/commands/delete_draft_permits.py
+++ b/parking_permits/management/commands/delete_draft_permits.py
@@ -21,7 +21,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         minutes = options["minutes"] + (60 * options["hours"])
-        time_limit = timezone.localtime() - timedelta(minutes=minutes)
+        now = timezone.localtime()
+        time_limit = now - timedelta(minutes=minutes)
 
         # Delete draft permits
         # NOTE: there should not be draft permits with orders, but exclude
@@ -49,7 +50,10 @@ class Command(BaseCommand):
         )
 
         if num_ext_requests := ext_requests.count():
-            ext_requests.update(status=ParkingPermitExtensionRequest.Status.CANCELLED)
+            ext_requests.update(
+                status=ParkingPermitExtensionRequest.Status.CANCELLED,
+                status_changed_at=now,
+            )
             self.stdout.write(
                 f"{num_ext_requests} pending permit extension request(s) cancelled"
             )

--- a/parking_permits/tests/commands/test_delete_draft_permits.py
+++ b/parking_permits/tests/commands/test_delete_draft_permits.py
@@ -23,6 +23,7 @@ def test_approved_ext_requests_not_cancelled():
     call_command("delete_draft_permits")
     ext_request.refresh_from_db()
     assert ext_request.is_approved()
+    assert not ext_request.status_changed_at
 
 
 @pytest.mark.django_db()
@@ -36,6 +37,7 @@ def test_recent_pending_ext_requests_not_cancelled():
     call_command("delete_draft_permits")
     ext_request.refresh_from_db()
     assert ext_request.is_pending()
+    assert not ext_request.status_changed_at
 
 
 @pytest.mark.django_db()
@@ -49,6 +51,7 @@ def test_pending_ext_requests_cancelled():
     call_command("delete_draft_permits")
     ext_request.refresh_from_db()
     assert ext_request.is_cancelled()
+    assert ext_request.status_changed_at
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
## Description

Ensure the `status_changed_at` timestamp is set when cancelling extension requests, for consistency with existing behaviour.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-815](https://helsinkisolutionoffice.atlassian.net/browse/PV-815)

## How Has This Been Tested?

Unit tests

## Manual Testing Instructions for Reviewers

Run `./manage.py delete_draft_permits` 

Any cancelled requests should also have `status_changed_at` set to current time.



[PV-815]: https://helsinkisolutionoffice.atlassian.net/browse/PV-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ