### PR TITLE
Change admin ui order date search to search orders

### DIFF
--- a/parking_permits/forms.py
+++ b/parking_permits/forms.py
@@ -1,3 +1,4 @@
+import datetime
 import functools
 import operator
 
@@ -328,17 +329,15 @@ class OrderSearchForm(SearchFormBase):
             has_filters = True
 
         if start_date:
-            # Find all orders with permits that are or will be valid after the given start date.
-            qs = qs.filter(
-                Q(permits__start_time__gte=start_date)
-                | Q(permits__end_time__isnull=True)
-                | Q(permits__end_time__gte=start_date)
-            )
+            qs = qs.filter(Q(created_at__gte=start_date))
             has_filters = True
 
         if end_date:
-            # Find all orders with permits that are or have been valid before the given end date.
-            qs = qs.filter(permits__start_time__lte=end_date)
+            # Make sure full end_date -day is included in the search
+            next_midnight = datetime.datetime(
+                end_date.year, end_date.month, end_date.day + 1
+            )
+            qs = qs.filter(Q(created_at__lte=next_midnight))
             has_filters = True
 
         if parking_zone:

--- a/parking_permits/tests/test_forms.py
+++ b/parking_permits/tests/test_forms.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
-from datetime import timezone as dt_tz
 
+import freezegun
 import pytest
 from django.test import TestCase
 from django.utils import timezone
@@ -545,148 +545,72 @@ class OrderSearchFormSortTestCase(TestCase):
 
 
 class OrderSearchFormDateRangeTestCase(TestCase):
-    def run_date_range_sub_tests(self, order, form_data, sub_tests):
-        """Utility function for running a suite of subtests specifically for the date range search.
+    @freezegun.freeze_time("2000-01-01")
+    def test_form_start_date_search_valid(self):
+        order = OrderFactory()
 
-        Creates a single parking permit with a start and an optional end time, assigns it to the given order,
-        and then asserts the result count."""
+        form_data = {"start_date": "1999-01-01"}
         form = OrderSearchForm(form_data)
         self.assertTrue(form.is_valid())
 
-        for sub_test in sub_tests:
-            permit_args = sub_test["permit"]
-            start_time = timezone.datetime(*permit_args["start_time"], tzinfo=dt_tz.utc)
-            # Set end_time only if its arguments exist in the subtest data.
-            end_time = (
-                timezone.datetime(*args, tzinfo=dt_tz.utc)
-                if (args := permit_args.get("end_time"))
-                else None
-            )
-            permit = ParkingPermitFactory(
-                orders=[order], start_time=start_time, end_time=end_time
-            )
+        qs = form.get_queryset()
+        self.assertEqual(qs.first(), order)
 
-            qs = form.get_queryset()
+    @freezegun.freeze_time("2000-01-01")
+    def test_form_start_date_search_no_results(self):
+        OrderFactory()
 
-            with self.subTest(form_data=form_data, **sub_test):
-                self.assertEqual(qs.count(), sub_test["expected_count"])
+        form_data = {"start_date": "2000-01-02"}
+        form = OrderSearchForm(form_data)
+        self.assertTrue(form.is_valid())
 
-            permit.delete()
+        qs = form.get_queryset()
+        self.assertEqual(qs.first(), None)
 
-    def test_form_start_date_search(self):
+    @freezegun.freeze_time("2000-01-01")
+    def test_form_end_date_search_valid(self):
         order = OrderFactory()
 
-        self.run_date_range_sub_tests(
-            order,
-            form_data={"start_date": "2000-01-01"},
-            sub_tests=[
-                {
-                    "msg": "Permit starts in the past",
-                    "permit": {"start_time": (1999, 12, 1)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit starts in the future",
-                    "permit": {"start_time": (2001, 1, 1)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit starts in the past, ends in the future",
-                    "permit": {"start_time": (1999, 1, 1), "end_time": (2001, 1, 1)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit both starts and ends in the past",
-                    "permit": {"start_time": (1999, 12, 1), "end_time": (1999, 12, 31)},
-                    "expected_count": 0,
-                },
-                {
-                    "msg": "Permit both starts and ends in the future",
-                    "permit": {"start_time": (2001, 1, 1), "end_time": (2002, 1, 1)},
-                    "expected_count": 1,
-                },
-            ],
-        )
+        form_data = {"end_date": "2000-01-01"}
+        form = OrderSearchForm(form_data)
+        self.assertTrue(form.is_valid())
 
-    def test_form_end_date_search(self):
+        qs = form.get_queryset()
+        self.assertEqual(qs.first(), order)
+
+    @freezegun.freeze_time("2000-01-01")
+    def test_form_end_date_search_no_results(self):
+        OrderFactory()
+
+        form_data = {"end_date": "1999-01-01"}
+        form = OrderSearchForm(form_data)
+        self.assertTrue(form.is_valid())
+
+        qs = form.get_queryset()
+        self.assertEqual(qs.first(), None)
+
+    @freezegun.freeze_time("2000-01-01")
+    def test_form_search_date_range(self):
         order = OrderFactory()
 
-        self.run_date_range_sub_tests(
-            order,
-            form_data={"end_date": "2000-01-01"},
-            sub_tests=[
-                {
-                    "msg": "Permit starts in the past",
-                    "permit": {"start_time": (1999, 12, 1)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit starts in the future",
-                    "permit": {"start_time": (2001, 1, 1)},
-                    "expected_count": 0,
-                },
-                {
-                    "msg": "Permit starts in the past, ends in the future",
-                    "permit": {"start_time": (1999, 1, 1), "end_time": (2001, 1, 1)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit both starts and ends in the past",
-                    "permit": {"start_time": (1999, 12, 1), "end_time": (1999, 12, 31)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit both starts and ends in the future",
-                    "permit": {"start_time": (2001, 1, 1), "end_time": (2002, 1, 1)},
-                    "expected_count": 0,
-                },
-            ],
-        )
+        form_data = {"start_date": "2000-01-01", "end_date": "2000-02-01"}
+        form = OrderSearchForm(form_data)
+        self.assertTrue(form.is_valid())
 
-    def test_form_with_start_date_and_end_date_search(self):
-        order = OrderFactory()
+        qs = form.get_queryset()
+        self.assertEqual(qs.first(), order)
 
-        self.run_date_range_sub_tests(
-            order,
-            form_data={"start_date": "2000-01-01", "end_date": "2000-01-31"},
-            sub_tests=[
-                {
-                    "msg": "Permit starts in the past",
-                    "permit": {"start_time": (1999, 12, 1)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit starts between the start and end date",
-                    "permit": {"start_time": (2000, 1, 16)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit starts after end date",
-                    "permit": {"start_time": (2000, 2, 1)},
-                    "expected_count": 0,
-                },
-                {
-                    "msg": "Permit starts in the past, ends before the end date",
-                    "permit": {"start_time": (1999, 12, 1), "end_time": (2000, 1, 16)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit starts in the past, ends after the end date",
-                    "permit": {"start_time": (1999, 12, 1), "end_time": (2000, 2, 1)},
-                    "expected_count": 1,
-                },
-                {
-                    "msg": "Permit both starts and ends in the past",
-                    "permit": {"start_time": (1999, 12, 1), "end_time": (1999, 12, 31)},
-                    "expected_count": 0,
-                },
-                {
-                    "msg": "Permit both starts and ends after the end date",
-                    "permit": {"start_time": (2100, 1, 1), "end_time": (2200, 1, 1)},
-                    "expected_count": 0,
-                },
-            ],
-        )
+    @freezegun.freeze_time("2000-01-01")
+    def test_form_date_range_search_multiple_results(self):
+        OrderFactory()
+        OrderFactory()
+
+        form_data = {"start_date": "2000-01-01", "end_date": "2000-02-01"}
+        form = OrderSearchForm(form_data)
+        self.assertTrue(form.is_valid())
+
+        qs = form.get_queryset()
+        self.assertEqual(qs.count(), 2)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description

Change admin ui order date search to search orders. Previously it used to search permits related to orders.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-831](https://helsinkisolutionoffice.atlassian.net/browse/PV-831)

## How Has This Been Tested?

Tested manually.

## Manual Testing Instructions for Reviewers

When searching orders, orders that are created within selected date range should be shown.

## Screenshots

<!-- Add screenshots if appropriate -->


[PV-831]: https://helsinkisolutionoffice.atlassian.net/browse/PV-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ