### PR TITLE
Add logging to payment view

### DIFF
--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -463,7 +463,9 @@ class PaymentView(APIView):
                 sync_with_parkkihubi(ext_request.permit)
                 send_permit_email(PermitEmailType.EXTENDED, ext_request.permit)
 
+            contract_type = ""
             for permit in order.permits.all():
+                contract_type = permit.contract_type
                 permit.status = ParkingPermitStatus.VALID
 
                 # Subscription renewed type order has always only one permit
@@ -515,7 +517,10 @@ class PaymentView(APIView):
                     )
 
                 sync_with_parkkihubi(permit)
-            logger.info(f"{order} is confirmed and order permits are set to VALID ")
+            logger.info(
+                f"{order} with talpa_order_id: {talpa_order_id} is confirmed \
+                        and order permits are set to VALID. Permit contract type is {contract_type}"
+            )
             return Response({"message": "Payment received"}, status=200)
         else:
             order.permit_extension_requests.cancel_pending()


### PR DESCRIPTION
## Description

Add permit and its contract type logging to payment view. talpa_order_id is already being logged.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-837](https://helsinkisolutionoffice.atlassian.net/browse/PV-837)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots

<!-- Add screenshots if appropriate -->


[PV-837]: https://helsinkisolutionoffice.atlassian.net/browse/PV-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ