### PR TITLE
Update VAT-based refund calculation to work with all orders

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -2,6 +2,7 @@ import logging
 import re
 from collections import Counter
 from copy import deepcopy
+from decimal import Decimal
 
 from ariadne import (
     MutationType,
@@ -81,7 +82,7 @@ from .models.parking_permit import (
 )
 from .models.refund import RefundStatus
 from .models.vehicle import VehiclePowerType
-from .resolver_utils import end_permits
+from .resolver_utils import create_refund, end_permits
 from .services import kami
 from .services.dvv import get_person_info
 from .services.mail import (
@@ -812,23 +813,16 @@ def resolve_update_resident_permit(
     for order, order_total_price_change in total_price_change_by_order.items():
         if customer_total_price_change < 0:
             logger.info("Creating refund for current order")
-            refund = Refund.objects.create(
-                name=customer.full_name,
+            refund = create_refund(
+                user=request.user,
+                permits=[permit],
                 order=order,
-                amount=-customer_total_price_change,
+                amount=Decimal(abs(customer_total_price_change)),
                 iban=iban,
-                vat=(
-                    order.order_items.first().vat
-                    if order.order_items.exists()
-                    else DEFAULT_VAT
-                ),
+                vat=(order.vat if order.vat else DEFAULT_VAT),
                 description=f"Refund for updating permit: {permit.id}",
             )
-            refund.permits.add(permit)
             logger.info(f"Refund for lowered permit price created: {refund}")
-            ParkingPermitEventFactory.make_create_refund_event(
-                permit, refund, created_by=request.user
-            )
             send_refund_email(RefundEmailType.CREATED, customer, [refund])
 
     bypass_traficom_validation = permit_info.get("bypass_traficom_validation", False)

--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -376,8 +376,8 @@ class OrderManager(SerializableMixin.SerializableManager):
                     payment_unit_price=payment_unit_price,
                     vat=product.vat,
                     quantity=period_quantity,
-                    start_time=start_date_to_datetime(start_date),
-                    end_time=end_date_to_datetime(end_date),
+                    start_time=start_date_to_datetime(period_start_date),
+                    end_time=end_date_to_datetime(period_end_date),
                 )
 
                 if product_end_date < order_item_end_date:

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -844,21 +844,8 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         unused_order_items = self.get_unused_order_items()
 
         for order_item, quantity, date_range in unused_order_items:
-            total += order_item.unit_price * quantity
+            total += order_item.payment_unit_price * quantity
         return total
-
-    def can_create_single_refund(self):
-        if not self.can_be_refunded:
-            return False
-
-        unused_order_items = self.get_unused_order_items()
-        if not unused_order_items:
-            return False
-        first_order_item, _, _ = unused_order_items[0]
-        first_vat = first_order_item.vat
-        return all(
-            order_item.vat == first_vat for order_item, _, _ in unused_order_items
-        )
 
     def parse_temporary_vehicle_times(
         self,

--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -1611,6 +1611,19 @@ class SubscriptionViewTestCase(APITestCase):
         talpa_order_item_id = "819daecd-5ebb-4a94-924e-9710069e9285"
         talpa_subscription_id = "f769b803-0bd0-489d-aa81-b35af391f391"
         customer = CustomerFactory()
+        LowEmissionCriteriaFactory(
+            start_date=datetime.datetime(2024, 1, 1),
+            end_date=datetime.datetime(2024, 12, 31),
+            nedc_max_emission_limit=None,
+            wltp_max_emission_limit=80,
+            euro_min_class_limit=6,
+        )
+        high_emission_vehicle = VehicleFactory(
+            power_type=VehiclePowerTypeFactory(identifier="01", name="Bensin"),
+            emission=100,
+            euro_class=6,
+            emission_type=EmissionType.WLTP,
+        )
         permit_start_time = datetime.datetime(
             2024, 3, 16, 10, 00, 0, tzinfo=datetime.timezone.utc
         )
@@ -1622,6 +1635,7 @@ class SubscriptionViewTestCase(APITestCase):
             customer=customer,
             start_time=permit_start_time,
             end_time=permit_end_time,
+            vehicle=high_emission_vehicle,
         )
         order = OrderFactory(
             talpa_order_id=talpa_order_id,
@@ -1643,6 +1657,7 @@ class SubscriptionViewTestCase(APITestCase):
             subscription=subscription,
             quantity=1,
             unit_price=unit_price,
+            payment_unit_price=unit_price,
         )
 
         url = reverse("parking_permits:subscription-notify")
@@ -1684,6 +1699,19 @@ class SubscriptionViewTestCase(APITestCase):
         talpa_order_item_id = "819daecd-5ebb-4a94-924e-9710069e9285"
         talpa_subscription_id = "f769b803-0bd0-489d-aa81-b35af391f391"
         customer = CustomerFactory()
+        LowEmissionCriteriaFactory(
+            start_date=datetime.datetime(2024, 1, 1),
+            end_date=datetime.datetime(2024, 12, 31),
+            nedc_max_emission_limit=None,
+            wltp_max_emission_limit=80,
+            euro_min_class_limit=6,
+        )
+        high_emission_vehicle = VehicleFactory(
+            power_type=VehiclePowerTypeFactory(identifier="01", name="Bensin"),
+            emission=100,
+            euro_class=6,
+            emission_type=EmissionType.WLTP,
+        )
         permit_start_time = datetime.datetime(
             2023, 3, 16, 10, 00, 0, tzinfo=datetime.timezone.utc
         )
@@ -1695,6 +1723,7 @@ class SubscriptionViewTestCase(APITestCase):
             customer=customer,
             start_time=permit_start_time,
             end_time=permit_end_time,
+            vehicle=high_emission_vehicle,
         )
         order = OrderFactory(
             talpa_order_id=talpa_order_id,
@@ -1716,6 +1745,7 @@ class SubscriptionViewTestCase(APITestCase):
             subscription=subscription,
             quantity=1,
             unit_price=unit_price,
+            payment_unit_price=unit_price,
             vat=Decimal(0.24),
         )
 


### PR DESCRIPTION
## Description

Updates:
- Update first item unused quantity calculation to take also future order item start time into account
- Refactor Refund creation to own utility
- Use order item payment unit price for total price calculation
- Use period start and end times in renewal orders

Add tests for:
- Creating a refund with permit extension request with multiple product timeframes
- Creating multiple vat refunds with permit extension request with multiple product timeframes
- Creating a refund with permit low emission vehicle
- Creating a refund with permit vehicle change with one product timeframe
- Creating a refund with permit vehicle change with multiple product timeframes
- Creating multiple vat refunds with permit vehicle change with one product timeframe
- Creating multiple vat refunds with permit vehicle change with multiple product timeframes

## Context

[PV-871](https://helsinkisolutionoffice.atlassian.net/browse/PV-871)

## How Has This Been Tested?

Through unit tests.

## Manual Testing Instructions for Reviewers

Test refund creations with:
- permit ending
- vehicle change
- address change

across the system in Webshop and Admin UI.
Observe frontend results, use Django Admin to observe results in database and validate email contents.

[PV-871]: https://helsinkisolutionoffice.atlassian.net/browse/PV-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ