### PR TITLE
Update refund order linking and VATs

### DIFF
--- a/parking_permits/resolver_utils.py
+++ b/parking_permits/resolver_utils.py
@@ -115,7 +115,6 @@ def create_fixed_period_refunds(
                     vat=vat,
                 )
             )
-
         if refunds:
             send_refund_email(RefundEmailType.CREATED, customer, refunds)
 

--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -1339,6 +1339,9 @@ class OrderViewTestCase(APITestCase):
             permit.end_time,
             datetime.datetime(2023, 5, 29, 23, 59, 0, tzinfo=datetime.timezone.utc),
         )
+        order_item = order.order_items.first()
+        self.assertAlmostEqual(order_item.vat, Decimal(0.255), delta=Decimal("0.01"))
+        self.assertEqual(order_item.vat_percentage, 25.5)
 
     @override_settings(DEBUG=True)
     def test_subscription_renewal_already_renewed(self):

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -4,6 +4,7 @@ import json
 import logging
 import time
 import uuid
+from decimal import Decimal
 
 from ariadne import convert_camel_case_to_snake
 from dateutil.relativedelta import relativedelta
@@ -656,6 +657,12 @@ class OrderView(APIView):
             )
             end_time = get_end_time(start_time, 1)
 
+            vat_percentage = (
+                Decimal(0)
+                if not validated_order_item_data.get("vatPercentage")
+                else Decimal(validated_order_item_data.get("vatPercentage"))
+            )
+
             OrderItem.objects.create(
                 talpa_order_item_id=validated_order_item_data.get("orderItemId"),
                 order=order,
@@ -664,7 +671,7 @@ class OrderView(APIView):
                 permit=permit,
                 unit_price=validated_order_item_data.get("priceGross"),
                 payment_unit_price=validated_order_item_data.get("rowPriceTotal"),
-                vat=validated_order_item_data.get("vatPercentage"),
+                vat=vat_percentage / 100,
                 quantity=validated_order_item_data.get("quantity"),
                 start_time=start_time,
                 end_time=end_time,


### PR DESCRIPTION
## Description

Updates:
- Update refund order linking from vehicle and address change processes to point to permit latest order
- Create renewal orders only with positive sums
- Use VAT from price change list
- Convert Talpa vat percentage to vat when creating new `OrderItem`
- Update tests

## Context

[PV-871](https://helsinkisolutionoffice.atlassian.net/browse/PV-871)

## How Has This Been Tested?

Manually and through unit tests.


[PV-871]: https://helsinkisolutionoffice.atlassian.net/browse/PV-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ