### PR TITLE
Add DVV-checks for Talpa rights of purchase

### DIFF
--- a/parking_permits/services/dvv.py
+++ b/parking_permits/services/dvv.py
@@ -71,6 +71,17 @@ def get_addresses(national_id_number):
     return primary_address, other_address
 
 
+def is_same_address(address, other_address):
+    if not address and not other_address:
+        return True
+    if not address or not other_address:
+        return False
+    return all(
+        address[key] == other_address[key]
+        for key in ["street_name", "street_number", "apartment", "city", "postal_code"]
+    )
+
+
 def _extract_address_data(address) -> Optional[DvvAddressInfo]:
     return (
         {


### PR DESCRIPTION
## Description

Compare permit address with DVV primary and other addresses and only allow continuing when addresses match.

Compare attributes `street_name`, `street_number`, `apartment`, `city` and `postal_code`.

Update Talpa rights of purchase tests and add new tests for address comparison.

## Context

[PV-845](https://helsinkisolutionoffice.atlassian.net/browse/PV-845)

## How Has This Been Tested?

Through updated unit tests.

## Manual Testing Instructions for Reviewers

This is better to test with Talpa explicitly also.


[PV-845]: https://helsinkisolutionoffice.atlassian.net/browse/PV-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ