### PR TITLE
Update VAT-based refund calculation

### DIFF
--- a/parking_permits/admin.py
+++ b/parking_permits/admin.py
@@ -257,13 +257,13 @@ class OrderAdmin(admin.ModelAdmin):
         "address_text",
         "parking_zone_name",
         "vehicles",
-        "get_vat_percent",
+        "get_vat_percents",
     )
     list_select_related = ("customer",)
     readonly_fields = (
         "talpa_order_id",
         "total_payment_price",
-        "get_vat_percent",
+        "get_vat_percents",
     )
     search_fields = (
         "customer__last_name",
@@ -279,9 +279,13 @@ class OrderAdmin(admin.ModelAdmin):
     )
     ordering = ("-created_at",)
 
-    @admin.display(description="Vat percent")
-    def get_vat_percent(self, obj):
-        return format(obj.vat_percent, ".2f") if obj.vat_percent else None
+    @admin.display(description="Vat percents")
+    def get_vat_percents(self, obj):
+        return (
+            ", ".join([format(vat * 100, ".2f") for vat in obj.vat_values])
+            if obj.vat_values
+            else None
+        )
 
 
 @admin.register(OrderItem)

--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -511,6 +511,11 @@ class Order(SerializableMixin, TimestampedModelMixin, UserStampedModelMixin):
         return sum([item.total_payment_price_vat for item in self.order_items.all()])
 
     @property
+    def vat_values(self):
+        # gather distinct vat values from all order items
+        return set([item.vat for item in self.order_items.all()])
+
+    @property
     def vat(self):
         return self.order_items.first().vat if self.order_items.exists() else Decimal(0)
 

--- a/parking_permits/resolver_utils.py
+++ b/parking_permits/resolver_utils.py
@@ -189,14 +189,14 @@ def end_permit(
             )
     else:
         # Cancel fixed period permit order when this is the last valid permit in that order
-        latest_order = permit.latest_order
-        if (
-            latest_order
-            and not latest_order.order_permits.filter(status=ParkingPermitStatus.VALID)
-            .exclude(pk=permit.pk)
-            .exists()
-        ):
-            latest_order.cancel(cancel_from_talpa=cancel_from_talpa)
+        for order in permit.orders.all():
+            if (
+                order
+                and not order.order_permits.filter(status=ParkingPermitStatus.VALID)
+                .exclude(pk=permit.pk)
+                .exists()
+            ):
+                order.cancel(cancel_from_talpa=cancel_from_talpa)
 
     permit.temp_vehicles.update(is_active=False)
 


### PR DESCRIPTION
## Description

Updates:
- Update refund calculation to use only the order of the first unused item.
- Automatically cancel all permit orders that do not have any other valid permits left in them.
- Update OrderAdmin to display all distinct order items VATs

## Context

[PV-877](https://helsinkisolutionoffice.atlassian.net/browse/PV-877)

## How Has This Been Tested?

Manually and through unit tests.

## Manual Testing Instructions for Reviewers

Test refund creation in Admin UI.

## Screenshots
![admin ui vat-based refunds](https://github.com/user-attachments/assets/87a1f205-d902-4e3a-8e8d-ec7850268ae5)




[PV-877]: https://helsinkisolutionoffice.atlassian.net/browse/PV-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ