### PR TITLE
Webshop permit preliminary status support

### DIFF
--- a/parking_permits/resolvers.py
+++ b/parking_permits/resolvers.py
@@ -543,7 +543,8 @@ def resolve_create_order(_obj, info, audit_msg: AuditMsg = None):
     request = info.context["request"]
     customer = request.user.customer
     permits = ParkingPermit.objects.filter(
-        customer=customer, status=ParkingPermitStatus.DRAFT
+        customer=customer,
+        status__in=[ParkingPermitStatus.DRAFT, ParkingPermitStatus.PRELIMINARY],
     )
     order = Order.objects.create_for_permits(permits, user=request.user)
     permits.update(status=ParkingPermitStatus.PAYMENT_IN_PROGRESS)


### PR DESCRIPTION
## Description

Add support for webshop permit preliminary status.
Also update customer permit module tests.

## Context

[PV-898](https://helsinkisolutionoffice.atlassian.net/browse/PV-898)

## How Has This Been Tested?

Manually via Admin UI and Webshop and through added/updated unit tests.

## Manual Testing Instructions for Reviewers

Test that preliminary permit creation can be bought from the Webshop.



[PV-898]: https://helsinkisolutionoffice.atlassian.net/browse/PV-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ