### PR TITLE
Fix a date bug where there might be gaps in days sent to talpa

### DIFF
--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -811,3 +811,13 @@ class OrderItem(SerializableMixin, TimestampedModelMixin):
             end_time = tz.localtime(self.end_time).strftime(DATE_FORMAT)
             return f"{start_time} - {end_time}"
         return ""
+
+    def adjusted_timeframe(self, start_time):
+        """
+        Custom timeframe used to make sure subsequent order items don't have gaps in days
+        """
+        if start_time and self.end_time:
+            start_time = tz.localtime(start_time).strftime(DATE_FORMAT)
+            end_time = tz.localtime(self.end_time).strftime(DATE_FORMAT)
+            return f"{start_time} - {end_time}"
+        return ""

--- a/parking_permits/tests/models/test_order.py
+++ b/parking_permits/tests/models/test_order.py
@@ -144,6 +144,8 @@ class TestOrderManager(TestCase):
         self.assertEqual(order_items[0].quantity, 4)
         self.assertEqual(order_items[1].unit_price, Decimal(50))
         self.assertEqual(order_items[1].quantity, 2)
+        total_quantity = order_items[0].quantity + order_items[1].quantity
+        self.assertEqual(total_quantity, 6)
 
     def test_create_for_permits_should_create_order_items_with_start_end_date_for_open_ended_permits(
         self,

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -417,7 +417,7 @@ class ParkingZoneTestCase(TestCase):
         ]
         products = self._create_zone_products(self.zone_a, product_detail_list)
         start_time = timezone.make_aware(datetime(2021, 2, 15))
-        end_time = get_end_time(start_time, 10)  # ends at 2021-2-14, 23:59
+        end_time = get_end_time(start_time, 10)  # ends at 2021-12-14, 23:59
         permit = ParkingPermitFactory(
             parking_zone=self.zone_a,
             contract_type=ContractType.FIXED_PERIOD,
@@ -432,6 +432,12 @@ class ParkingZoneTestCase(TestCase):
         self.assertEqual(products_with_quantities[1][1], 2)
         self.assertEqual(products_with_quantities[2][0].id, products[2].id)
         self.assertEqual(products_with_quantities[2][1], 4)
+        total_quantity = (
+            products_with_quantities[0][1]
+            + products_with_quantities[1][1]
+            + products_with_quantities[2][1]
+        )
+        self.assertEqual(total_quantity, 10)
 
     @freeze_time(timezone.make_aware(datetime(2024, 1, 1)))
     def test_active_temporary_vehicles_active_in_time_range(self):
@@ -476,7 +482,7 @@ class ParkingZoneTestCase(TestCase):
         ]
         products = self._create_zone_products(self.zone_a, product_detail_list)
         start_time = timezone.make_aware(datetime(2021, 2, 15))
-        end_time = get_end_time(start_time, 10)  # ends at 2021-2-14, 23:59
+        end_time = get_end_time(start_time, 10)  # ends at 2021-12-14, 23:59
         permit = ParkingPermitFactory(
             parking_zone=self.zone_a,
             contract_type=ContractType.FIXED_PERIOD,
@@ -491,6 +497,12 @@ class ParkingZoneTestCase(TestCase):
         self.assertEqual(products_with_quantities[1][1], 3)
         self.assertEqual(products_with_quantities[2][0].id, products[2].id)
         self.assertEqual(products_with_quantities[2][1], 4)
+        total_quantity = (
+            products_with_quantities[0][1]
+            + products_with_quantities[1][1]
+            + products_with_quantities[2][1]
+        )
+        self.assertEqual(total_quantity, 10)
 
     def test_get_products_with_quantities_should_raise_error_when_products_does_not_cover_permit_duration(
         self,


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Fix a date bug where there might be gaps in days sent to talpa.
Improve testing.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[PV-897](https://helsinkisolutionoffice.atlassian.net/browse/PV-897)

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->
Could not be tested locally due to data issues.

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->
When permit has multiple products, the start date of the second product should now be correct in talpa webshop.
## Screenshots

<!-- Add screenshots if appropriate -->


[PV-897]: https://helsinkisolutionoffice.atlassian.net/browse/PV-897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ