### PR TITLE
Increase Gunicorn header size limit

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -2,6 +2,7 @@
 
 wsgi_app = "project.wsgi"
 bind = "0.0.0.0:8888"
+limit_request_field_size = 65536
 
 accesslog = "-"  # '-' makes gunicorn log to stdout
 errorlog = "-"  # '-' makes gunicorn log to stderr


### PR DESCRIPTION
## Description

Increase Gunicorn allowed size of an HTTP request header field to 64 kB.

Some users have a lot of associated AD-groups in them, so it is necessary to increase HTTP request header size.

## Context

[PV-904](https://helsinkisolutionoffice.atlassian.net/browse/PV-904)

## How Has This Been Tested?

Manually with GraphQL admin endpoint.


[PV-904]: https://helsinkisolutionoffice.atlassian.net/browse/PV-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ