### PR TITLE
Update permit renewal end time calculation

### DIFF
--- a/parking_permits/admin.py
+++ b/parking_permits/admin.py
@@ -159,10 +159,6 @@ class ParkingPermitAdmin(admin.ModelAdmin):
     )
     list_filter = ("contract_type", "status")
     list_select_related = ("customer", "vehicle", "parking_zone")
-    ordering = (
-        "customer__first_name",
-        "customer__last_name",
-    )
     raw_id_fields = (
         "address",
         "customer",
@@ -227,6 +223,7 @@ class VehicleAdmin(admin.ModelAdmin):
 class RefundAdmin(admin.ModelAdmin):
     search_fields = ("name", "iban", "orders__id")
     list_display = (
+        "id",
         "name",
         "iban",
         "get_orders",

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -419,7 +419,8 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
     @property
     def months_left(self):
         if self.is_open_ended:
-            return None
+            # if the open-ended permit is not yet started, return 1
+            return 1 if self.start_time > timezone.now() else None
         return self.month_count - self.months_used
 
     @property
@@ -430,6 +431,8 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
     @property
     def current_period_end_time(self):
+        if self.is_open_ended:
+            return self.end_time
         return self.current_period_end_time_with_fixed_months(self.months_used)
 
     @property

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -820,11 +820,10 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
     def renew_open_ended_permit(self):
         """Add month to open-ended permit after subscription renewal"""
+
         if self.contract_type != ContractType.OPEN_ENDED:
             raise ValueError("This permit is not open-ended so cannot be renewed")
-        self.end_time = increment_end_time(
-            self.start_time, self.end_time or self.current_period_end_time(), months=1
-        )
+        self.end_time = increment_end_time(self.start_time, self.end_time, months=1)
         self.save()
 
     def extend_permit(self, additional_months):

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -927,6 +927,7 @@ class ParkingPermitTestCase(TestCase):
             end_time=now + relativedelta(months=4, days=-1),
         )
         secondary = ParkingPermitFactory(
+            contract_type=ContractType.FIXED_PERIOD,
             customer=primary.customer,
             primary_vehicle=False,
             end_time=now + relativedelta(months=1, days=-1),

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -1182,7 +1182,7 @@ class ParkingPermitTestCase(TestCase):
         permit = ParkingPermitFactory(
             status=ParkingPermitStatus.VALID,
             contract_type=ContractType.OPEN_ENDED,
-            start_time=timezone.make_aware(datetime(2024, 1, 1, 12, 0), pytz.UTC),
+            start_time=timezone.make_aware(datetime(2024, 1, 11, 12, 0), pytz.UTC),
             end_time=timezone.make_aware(datetime(2024, 3, 10, 21, 59), pytz.UTC),
             month_count=1,
         )
@@ -1206,7 +1206,7 @@ class ParkingPermitTestCase(TestCase):
         permit = ParkingPermitFactory(
             status=ParkingPermitStatus.VALID,
             contract_type=ContractType.OPEN_ENDED,
-            start_time=timezone.make_aware(datetime(2024, 1, 1, 12, 0), pytz.UTC),
+            start_time=timezone.make_aware(datetime(2024, 1, 13, 12, 0), pytz.UTC),
             end_time=timezone.make_aware(datetime(2024, 10, 12, 20, 59), pytz.UTC),
             month_count=1,
         )

--- a/parking_permits/tests/test_utils.py
+++ b/parking_permits/tests/test_utils.py
@@ -367,6 +367,16 @@ class DiffMonthsFloorTestCase(TestCase):
         self.assertEqual(diff_months_floor(date(2021, 10, 15), date(2021, 10, 1)), 0)
         self.assertEqual(diff_months_floor(date(2021, 12, 1), date(2021, 10, 1)), 0)
         self.assertEqual(diff_months_floor(date(2021, 1, 1), date(2021, 1, 1)), 0)
+        self.assertEqual(diff_months_floor(date(2024, 1, 31), date(2024, 2, 29)), 1)
+        self.assertEqual(diff_months_floor(date(2024, 1, 31), date(2024, 3, 1)), 1)
+        self.assertEqual(diff_months_floor(date(2024, 1, 31), date(2024, 2, 28)), 0)
+        self.assertEqual(diff_months_floor(date(2025, 1, 31), date(2025, 2, 28)), 1)
+        self.assertEqual(diff_months_floor(date(2025, 1, 30), date(2025, 2, 28)), 1)
+        self.assertEqual(diff_months_floor(date(2025, 1, 29), date(2025, 2, 28)), 1)
+        self.assertEqual(diff_months_floor(date(2025, 1, 28), date(2025, 2, 28)), 1)
+        self.assertEqual(diff_months_floor(date(2025, 1, 27), date(2025, 2, 28)), 1)
+        self.assertEqual(diff_months_floor(date(2025, 2, 1), date(2025, 2, 28)), 0)
+        self.assertEqual(diff_months_floor(date(2025, 2, 1), date(2025, 3, 1)), 1)
 
 
 class DiffMonthsCeilTestCase(TestCase):

--- a/parking_permits/utils.py
+++ b/parking_permits/utils.py
@@ -136,30 +136,10 @@ def get_last_day_of_month(date: datetime):
 
 def increment_end_time(start_time, end_time, months=1):
     """
-    The logic for this function is as follows:
-    - If start_time is 1st of the month, always set end_time to next month's last day.
-    - If end_time is 28th or later, increment end_time by a month - 1 day.
-    - If end_time is 28th or later AND start_time is in February, set end_time start_time - 1 day.
-    - If end_time is end_time is between 1-27, increment end_time by a month.
+    Calculate the end time by adding `months` to the start time.
     """
-    existing_end_time = end_time
-    next_end_time = existing_end_time + relativedelta(months=1)
-
-    end_day = next_end_time.day
-    if existing_end_time.month == 2 and existing_end_time.day > 27:
-        end_day = get_last_day_of_month(next_end_time)
-        if next_end_time.day >= 28 and start_time.day > 1:
-            end_day = start_time.day - 1
-    if next_end_time.month == 2 and existing_end_time.day > 27:
-        end_day = get_last_day_of_month(next_end_time)
-    if existing_end_time.month in [4, 6, 9, 11] and existing_end_time.day == 30:
-        end_day = 31
-
-    end_time = end_time.astimezone(tz.get_default_timezone())
-    end_time += relativedelta(months=months)
-
-    end_time = end_time.replace(day=end_day)
-    return normalize_end_time(end_time)
+    month_diff = diff_months_floor(start_time, end_time + relativedelta(days=1))
+    return get_end_time(start_time, month_diff + months)
 
 
 def normalize_end_time(end_time):


### PR DESCRIPTION
## Description

Update the open ended permit renewal process permit end time calculation. Calculate the end time by adding `months` to the start time.

Other updates:
- Update DST-testcases
- Add more tests for edge cases
- Update open-ended permit months left calculation
- Update Django Admin fields and ordering


## Context

[PV-908](https://helsinkisolutionoffice.atlassian.net/browse/PV-908)

## How Has This Been Tested?

Through enhanced unit tests.


[PV-908]: https://helsinkisolutionoffice.atlassian.net/browse/PV-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ