### PR TITLE
Fix to multiple announcemenent emails getting sent

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 08:50+0200\n"
+"POT-Creation-Date: 2024-12-13 08:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -407,6 +407,9 @@ msgstr "Otsikko (SV)"
 msgid "Content (SV)"
 msgstr "Sisältö (SV)"
 
+msgid "Emails handled"
+msgstr "Sähköpostit käsitelty"
+
 msgid "Company name"
 msgstr "Yrityksen nimi"
 
@@ -595,6 +598,9 @@ msgstr "Maksun tuotteen hinta"
 
 msgid "Quantity"
 msgstr "Määrä"
+
+msgid "Is refunded"
+msgstr "Palautettu"
 
 msgid "Order item"
 msgstr "Tilausrivi"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-22 08:50+0200\n"
+"POT-Creation-Date: 2024-12-13 08:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -403,6 +403,9 @@ msgstr "Ämne (SV)"
 msgid "Content (SV)"
 msgstr "Innehåll (SV)"
 
+msgid "Emails handled"
+msgstr "E-post hanterad"
+
 msgid "Company name"
 msgstr "Företagets namn"
 
@@ -591,6 +594,9 @@ msgstr "Pris"
 
 msgid "Quantity"
 msgstr "Antal"
+
+msgid "Is refunded"
+msgstr "Återbetalad"
 
 msgid "Order item"
 msgstr "Beställningsrad"

--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -30,7 +30,7 @@ def handle_announcement_emails():
         customers = Customer.objects.filter(
             zone__in=announcement.parking_zones.all(),
             permits__status=ParkingPermitStatus.VALID,
-        )
+        ).distinct()
         logger.info(
             f"Found {customers.count()} customers for announcement {announcement.pk}"
         )

--- a/parking_permits/tests/test_cron.py
+++ b/parking_permits/tests/test_cron.py
@@ -401,6 +401,11 @@ class AnnouncementEmailHandlingTestCase(TestCase):
             parking_zone=self.zone_c,
             status=ParkingPermitStatus.CANCELLED,
         )
+        self.customer_1_permit_4 = ParkingPermitFactory(
+            customer=self.customer_1,
+            parking_zone=self.zone_a,
+            status=ParkingPermitStatus.VALID,
+        )
 
         self.customer_2_permit_1 = ParkingPermitFactory(
             customer=self.customer_2,


### PR DESCRIPTION
If customer has two permits in the same zone they would've gotten duplicate email from the announcement.

REFS: PV-901

## Description

Fixes issue with duplicate announcement emails getting sent when customer has many permits in same zone.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[jira-id](https://helsinkisolutionoffice.atlassian.net/browse/<jira-id>)

## How Has This Been Tested?

Tweak existing tests.

