### PR TITLE
Use permit zone in announcement handling.

### DIFF
--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -28,7 +28,7 @@ def handle_announcement_emails():
     logger.info(f"Found unhandled announcements: {announcements.count()}")
     for announcement in announcements:
         customers = Customer.objects.filter(
-            zone__in=announcement.parking_zones.all(),
+            permits__parking_zone__in=announcement.parking_zones.all(),
             permits__status=ParkingPermitStatus.VALID,
         ).distinct()
         logger.info(

--- a/parking_permits/tests/test_cron.py
+++ b/parking_permits/tests/test_cron.py
@@ -382,9 +382,9 @@ class AnnouncementEmailHandlingTestCase(TestCase):
         self.zone_b = ParkingZoneFactory(name="B")
         self.zone_c = ParkingZoneFactory(name="C")
         self.announcement = AnnouncementFactory(subject_en="Test announcement")
-        self.customer_1 = CustomerFactory(zone=self.zone_a, email="test@mail.com")
-        self.customer_2 = CustomerFactory(zone=self.zone_b, email="test2@mail.com")
-        self.customer_3 = CustomerFactory(zone=self.zone_c, email="test3@mail.com")
+        self.customer_1 = CustomerFactory(email="test@mail.com")
+        self.customer_2 = CustomerFactory(email="test2@mail.com")
+        self.customer_3 = CustomerFactory(email="test3@mail.com")
 
         self.customer_1_permit_1 = ParkingPermitFactory(
             customer=self.customer_1,


### PR DESCRIPTION
Refs: PV-901

## Description

Use permit's parking zone instead of customer zone when handling announcement emails.

## Context
Emails not getting sent properly to customers. This PR fixes it.
https://helsinkisolutionoffice.atlassian.net/browse/PV-901


## How Has This Been Tested?

Edit tests to use parking permit zone instead of customer zone.
