### PR TITLE
fix issue with low emission consent command

### DIFF
--- a/parking_permits/management/commands/disable_consent_low_emission.py
+++ b/parking_permits/management/commands/disable_consent_low_emission.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         ).select_related("power_type")
         i = 0
         for vehicle in vehicles:
-            if not vehicle.power_type.is_electric():
+            if not vehicle.power_type.is_electric:
                 vehicle.consent_low_emission_accepted = False
                 if not dry_run:
                     vehicle.save()


### PR DESCRIPTION
## Description

Management command `disable_consent_low_emission` would fail due to typeError.
This PR fixes the error.

REFS: https://helsinkisolutionoffice.atlassian.net/browse/PV-880
