### PR TITLE
Mark open-ended order items as refunded first time

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -594,7 +594,7 @@ msgid "Unit price"
 msgstr "Tuotteen hinta"
 
 msgid "Payment unit price"
-msgstr "Maksun tuotteen hinta"
+msgstr "Maksun hinta"
 
 msgid "Quantity"
 msgstr "Määrä"

--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -684,6 +684,9 @@ class Subscription(SerializableMixin, TimestampedModelMixin, UserStampedModelMix
                 vat=(order.vat if order.vat else DEFAULT_VAT),
                 description=f"Refund for ending permit {str(permit.id)}",
             )
+            # Mark the order item as refunded
+            order_item.is_refunded = True
+            order_item.save()
             send_refund_email(RefundEmailType.CREATED, permit.customer, [refund])
             logger.info(f"Refund for permit {str(permit.id)} created successfully")
 

--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -317,7 +317,8 @@ class OrderManager(SerializableMixin.SerializableManager):
             new_order.save()
 
         for permit in customer_permits:
-            new_order.vehicles.append(permit.vehicle.registration_number)
+            vehicle = permit.next_vehicle if permit.next_vehicle else permit.vehicle
+            new_order.vehicles.append(vehicle.registration_number)
             new_order.save()
             start_date = tz.localdate(permit.next_period_start_time)
             end_date = tz.localdate(permit.end_time)
@@ -354,7 +355,6 @@ class OrderManager(SerializableMixin.SerializableManager):
                         "Error on product date ranges or order item date ranges"
                     )
 
-                vehicle = permit.next_vehicle if permit.next_vehicle else permit.vehicle
                 is_low_emission = vehicle.is_low_emission
                 unit_price = product.get_modified_unit_price(
                     is_low_emission, permit.is_secondary_vehicle


### PR DESCRIPTION
## Description

Updates:
- Mark open-ended order items as refunded, when refunded first time
- In Order renewal process, use next vehicle in new order when it is available
- Update finnish translation

## Context

[PV-910](https://helsinkisolutionoffice.atlassian.net/browse/PV-910)

## How Has This Been Tested?

Manually with following use-cases:
- Webshop permit ending immediately (open-ended permit)
- Webshop permit ending after current period (open-ended permit)
- Webshop permit ending immediately (fixed-period permit)
- Webshop permit ending after current period (fixed-period permit)
- Admin UI permit ending immediately (fixed-period permit)
- Admin UI permit ending after current period (fixed-period permit)


[PV-910]: https://helsinkisolutionoffice.atlassian.net/browse/PV-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ