### PR TITLE
Don't disable temporary vehicle immediately when ending permit

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -817,6 +817,7 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
             or end_type == ParkingPermitEndType.PREVIOUS_DAY_END
         ):
             self.status = ParkingPermitStatus.CLOSED
+            self.temp_vehicles.update(is_active=False, end_time=end_time)
 
         self.cancel_extension_requests()
         self.save()

--- a/parking_permits/resolver_utils.py
+++ b/parking_permits/resolver_utils.py
@@ -173,9 +173,10 @@ def end_permit(
 
     Ends Subscription for open ended permit and issues refund if applicable.
 
-    Any active temporary vehicles are deactivated.
-
     Parkkihubi is updated with new status.
+
+    Any active temporary vehicles are deactivated in permit.end_permit()
+    if end_type in [IMMEDIATELY, PREVIOUS_DAY_END]
     """
     if permit.is_open_ended:
         if subscription := (
@@ -198,8 +199,6 @@ def end_permit(
                 .exists()
             ):
                 order.cancel(cancel_from_talpa=cancel_from_talpa)
-
-    permit.temp_vehicles.update(is_active=False)
 
     if permit.consent_low_emission_accepted and permit.vehicle.is_low_emission:
         send_vehicle_low_emission_discount_email(

--- a/parking_permits/tests/test_customer_permit.py
+++ b/parking_permits/tests/test_customer_permit.py
@@ -433,6 +433,8 @@ class UpdateCustomerPermitTestCase(TestCase):
     def setUp(self):
         self.cus_a = CustomerFactory(first_name="Firstname A", last_name="")
         self.cus_b = CustomerFactory(first_name="Firstname B", last_name="")
+        zone_a = ParkingZoneFactory(name="A")
+        zone_b = ParkingZoneFactory(name="B")
 
         self.c_a_draft = ParkingPermitFactory(
             customer=self.cus_a,
@@ -440,8 +442,12 @@ class UpdateCustomerPermitTestCase(TestCase):
             address=self.cus_a.primary_address,
             parking_zone=self.cus_a.primary_address.zone,
         )
-        self.c_a_closed = ParkingPermitFactory(customer=self.cus_a, status=CLOSED)
-        self.c_b_valid = ParkingPermitFactory(customer=self.cus_b, status=VALID)
+        self.c_a_closed = ParkingPermitFactory(
+            customer=self.cus_a, status=CLOSED, parking_zone=zone_a
+        )
+        self.c_b_valid = ParkingPermitFactory(
+            customer=self.cus_b, status=VALID, parking_zone=zone_b
+        )
         self.c_b_preliminary = ParkingPermitFactory(
             customer=self.cus_b, status=PRELIMINARY
         )


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Don't disable temporary vehicle immediatly when ending permit.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

Previously temporary vehicles were disabled immediatly always when used ended their permit.

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->
Manually and automated testing.

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->
If user has a temporary vehicle and ends their permit, the temporary vehicle is disabled only when the permit ends, or as before if permit has a longer period left than temporary vehicle.

## Screenshots

<!-- Add screenshots if appropriate -->
