### PR TITLE
Add hard limit for amount of returned products

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -638,13 +638,16 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
         # for each product in our range, find the start and end dates
         # of whole months within that range
-        while product and start_date < end_date:
+        # add hard limit that more products can't be returned than there is months
+        loop_count = 0
+        while product and start_date < end_date and loop_count < month_count:
             yield {
                 "product": product,
                 "start_date": start_date,
                 "end_date": start_date + relativedelta(months=1, days=-1),
             }
             start_date += relativedelta(months=1)
+            loop_count += 1
 
             if start_date > product.end_date:
                 product = next(products, None)

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -884,7 +884,7 @@ class ParkingPermitTestCase(TestCase):
         ProductFactory(
             zone=permit.parking_zone,
             type=ProductType.RESIDENT,
-            start_date=(now - timedelta(days=61)).date(),
+            start_date=(now + timedelta(days=61)).date(),
             end_date=(now + timedelta(days=365)).date(),
             unit_price=Decimal("40.00"),
         )


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
Sometimes this function could return one product
more than month_count, add hard limit so more
than month_count products can't be returned.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->
As far as I know, the bug only occured if permit end date happened to be 29.1.2025.
In such case, if the user would add two or more months to extension request, which
caused extra month to appear.

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->
Tested manually.

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->
Users should not be able to buy more than 12 months of extension.

## Screenshots

<!-- Add screenshots if appropriate -->
