### PR TITLE
Fix permit getting wrong price

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -1040,6 +1040,13 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
             permit_end_date = timezone.localdate(self.end_time)
             return qs.get_products_with_quantities(permit_start_date, permit_end_date)
 
+    def get_currently_active_product(self):
+        """Use if multiple products for single zone, gets
+        the one that's currently active"""
+
+        current_time = timezone.now()
+        return self.get_products_for_resident().get_for_date(current_time)
+
 
 class ParkingPermitEvent(TimestampedModelMixin, UserStampedModelMixin):
     class EventType(models.TextChoices):

--- a/parking_permits/views.py
+++ b/parking_permits/views.py
@@ -305,17 +305,11 @@ class TalpaResolvePrice(APIView):
 
         try:
             permit = ParkingPermit.objects.get(pk=permit_id)
-            products_with_quantity = permit.get_products_with_quantities()
-            if not products_with_quantity:
-                return bad_request_response("No products found for permit")
-            product_with_quantity = products_with_quantity[0]
-            if not product_with_quantity:
-                return bad_request_response(
-                    "Product with quantity not found for permit"
-                )
-            product = product_with_quantity[0]
+            product = permit.get_currently_active_product()
+
             if not product:
-                return bad_request_response("Product not found")
+                return bad_request_response("No products found for permit")
+
             response = snake_to_camel_dict(
                 {
                     "subscription_id": subscription_id,


### PR DESCRIPTION
## Description

Fix permit getting wrong price.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

If there is multiple products for a zone and permit has started before the price changed for the zone, the permit could get the previous price.

## How Has This Been Tested?

<!-- Explain what automated and manual testing approaches you have used -->
Added automatic testing.

## Manual Testing Instructions for Reviewers

<!-- Make it easy for reviewers to test your changes by providing instructions -->
If permit has a start date and zone price changed after that, the permit should now get the new price for months after the price change.

## Screenshots

<!-- Add screenshots if appropriate -->
