### PR TITLE
SHPPWS-93: Update open-ended end time calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: test
     strategy:
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/ubuntu/ubuntu:20.04 as base
+FROM public.ecr.aws/ubuntu/ubuntu:22.04 as base
 
 WORKDIR /app
 

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -432,6 +432,11 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
     @property
     def current_period_end_time(self):
         if self.is_open_ended:
+            # If open-ended permit is already renewed for the new period,
+            # then use previous period end time
+            now = timezone.now()
+            if self.end_time and self.end_time - relativedelta(months=1) > now:
+                return self.end_time - relativedelta(months=1)
             return self.end_time
         return self.current_period_end_time_with_fixed_months(self.months_used)
 

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -273,9 +273,9 @@ class ParkingZoneTestCase(TestCase):
         pending.refresh_from_db()
         assert pending.is_cancelled()
 
-    @freeze_time(timezone.make_aware(datetime(2021, 11, 20, 12, 10, 50)))
-    def test_should_set_end_time_to_now_if_end_permit_immediately(self):
-        start_time = timezone.make_aware(datetime(2021, 11, 15))
+    @freeze_time(timezone.make_aware(datetime(2025, 4, 18, 12, 10, 50)))
+    def test_fixed_period_permit_end_time_when_ended_immediately(self):
+        start_time = timezone.make_aware(datetime(2025, 4, 15))
         end_time = get_end_time(start_time, 6)
         permit = ParkingPermitFactory(
             contract_type=ContractType.FIXED_PERIOD,
@@ -285,12 +285,27 @@ class ParkingZoneTestCase(TestCase):
         )
         permit.end_permit(ParkingPermitEndType.IMMEDIATELY)
         self.assertEqual(
-            permit.end_time, timezone.make_aware(datetime(2021, 11, 20, 12, 10, 50))
+            permit.end_time, timezone.make_aware(datetime(2025, 4, 18, 12, 10, 50))
         )
 
-    @freeze_time(timezone.make_aware(datetime(2021, 11, 20, 12, 10, 50)))
-    def test_should_set_end_time_to_period_end_if_end_permit_after_current_period(self):
-        start_time = timezone.make_aware(datetime(2021, 11, 15))
+    @freeze_time(timezone.make_aware(datetime(2025, 4, 18, 12, 10, 50)))
+    def test_open_ended_permit_end_time_when_ended_immediately(self):
+        start_time = timezone.make_aware(datetime(2025, 4, 15))
+        end_time = get_end_time(start_time, 1)
+        permit = ParkingPermitFactory(
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=start_time,
+            end_time=end_time,
+            month_count=1,
+        )
+        permit.end_permit(ParkingPermitEndType.IMMEDIATELY)
+        self.assertEqual(
+            permit.end_time, timezone.make_aware(datetime(2025, 4, 18, 12, 10, 50))
+        )
+
+    @freeze_time(timezone.make_aware(datetime(2025, 4, 18, 12, 10, 50)))
+    def test_fixed_period_permit_end_time_when_ended_after_current_period(self):
+        start_time = timezone.make_aware(datetime(2025, 4, 15))
         end_time = get_end_time(start_time, 6)
         permit = ParkingPermitFactory(
             contract_type=ContractType.FIXED_PERIOD,
@@ -301,7 +316,39 @@ class ParkingZoneTestCase(TestCase):
         permit.end_permit(ParkingPermitEndType.AFTER_CURRENT_PERIOD)
         self.assertEqual(
             permit.end_time,
-            timezone.make_aware(datetime(2021, 12, 14, 23, 59, 59, 999999)),
+            timezone.make_aware(datetime(2025, 5, 14, 23, 59, 59, 999999)),
+        )
+
+    @freeze_time(timezone.make_aware(datetime(2025, 4, 18, 12, 10, 50)))
+    def test_open_ended_permit_end_time_when_ended_after_current_period(self):
+        start_time = timezone.make_aware(datetime(2025, 4, 15))
+        end_time = get_end_time(start_time, 2)
+        permit = ParkingPermitFactory(
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        permit.end_permit(ParkingPermitEndType.AFTER_CURRENT_PERIOD)
+        self.assertEqual(
+            permit.end_time,
+            timezone.make_aware(datetime(2025, 5, 14, 23, 59, 59, 999999)),
+        )
+
+    @freeze_time(timezone.make_aware(datetime(2025, 4, 18, 12, 10, 50)))
+    def test_open_ended_permit_end_time_when_ended_after_current_period_and_already_renewed(
+        self,
+    ):
+        start_time = timezone.make_aware(datetime(2025, 3, 20))
+        end_time = get_end_time(start_time, 2)
+        permit = ParkingPermitFactory(
+            contract_type=ContractType.OPEN_ENDED,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        permit.end_permit(ParkingPermitEndType.AFTER_CURRENT_PERIOD)
+        self.assertEqual(
+            permit.end_time,
+            timezone.make_aware(datetime(2025, 4, 19, 23, 59, 59, 999999)),
         )
 
     @freeze_time(timezone.make_aware(datetime(2021, 11, 20, 12, 10, 50)))

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ ariadne-django                         # schema-first graphql server implementat
 dj-database-url                        # to be able to parse DATABASE_URL
 django-environ                         # Read .env file
 django-extensions                      # useful django extensions
-django                                 # web framework itself
+django==5.1.*                          # web framework itself
 djangorestframework                    # creating rest APIs
 gunicorn                               # application server
 psycopg2-binary                        # postgres database adapter

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 anyio==4.9.0
     # via starlette
-ariadne==0.26.1
+ariadne==0.26.2
     # via ariadne-django
 ariadne-django==0.3.0
     # via -r requirements.in
@@ -35,7 +35,7 @@ deprecation==2.1.0
     # via django-helusers
 dj-database-url==2.3.0
     # via -r requirements.in
-django==5.2
+django==5.1.8
     # via
     #   -r requirements.in
     #   ariadne-django
@@ -129,9 +129,9 @@ requests==2.32.3
     #   -r requirements.in
     #   django-helusers
     #   drf-oidc-auth
-rsa==4.9
+rsa==4.9.1
     # via python-jose
-sentry-sdk==2.25.1
+sentry-sdk==2.26.1
     # via -r requirements.in
 six==1.17.0
     # via
@@ -142,7 +142,7 @@ sniffio==1.3.1
     # via anyio
 sqlparse==0.5.3
     # via django
-starlette==0.46.1
+starlette==0.46.2
     # via ariadne
 typing-extensions==4.13.2
     # via


### PR DESCRIPTION
## Description

Features:
- If open-ended permit is already renewed for the new period,
then use previous period end time
- Add/update related tests
- Update requirements
- Downgrade to Django 5.1 for now to support also PostgreSQL 13.