### PR TITLE
SHPPWS-92: Refund only confirmed extension requests

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -381,6 +381,10 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         return self.status == ParkingPermitStatus.VALID
 
     @property
+    def is_closed(self):
+        return self.status == ParkingPermitStatus.CLOSED
+
+    @property
     def is_open_ended(self):
         return self.contract_type == ContractType.OPEN_ENDED
 
@@ -992,11 +996,14 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         return unused_order_items
 
     def get_unused_order_items_for_order(self, order):
+        from .order import OrderStatus
+
         unused_start_date = timezone.localdate(self.next_period_start_time)
 
         order_items = order.order_items.filter(
             end_time__date__gte=unused_start_date,
             is_refunded=False,
+            order__status=OrderStatus.CONFIRMED,
             permit=self,
         ).order_by("start_time")
 

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -768,7 +768,7 @@ class ParkingZoneTestCase(TestCase):
             end_time=end_time,
             month_count=12,
         )
-        Order.objects.create_for_permits([permit])
+        Order.objects.create_for_permits([permit], status=OrderStatus.CONFIRMED)
         permit.refresh_from_db()
         permit.status = ParkingPermitStatus.VALID
         permit.save()


### PR DESCRIPTION
## Description

Refund only confirmed extension requests.

This PR adds an extra check that will guarantee, that only confirmed order's order items will be taken into account when the permit refunds are being done.

Add tests for all extension request statuses when permit is closed by automatic expiration
of permits cronjob after original permit validity period.

Refs: SHPPWS-92

## How Has This Been Tested?

Manually and through new unit tests.
