### PR TITLE
Permit active temporary vehicle and expiration remind updates

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-13 08:15+0200\n"
+"POT-Creation-Date: 2025-05-13 07:26+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -212,6 +212,9 @@ msgstr ""
 msgid "You can buy permit only for address %(primary_address)s."
 msgstr "Voit ostaa pysäköintitunnuksen vain osoitteelle %(primary_address)s."
 
+msgid "Source: Transport register, Traficom"
+msgstr "Lähde: Liikenneasioidenrekisteri, Traficom"
+
 msgid "Forbidden"
 msgstr "Lupa evätty"
 
@@ -340,6 +343,9 @@ msgstr "Palautukset"
 
 msgid "Refund ID"
 msgstr "Palautusnumero"
+
+msgid "incl. VAT"
+msgstr "sis. ALV"
 
 msgid "Extra info"
 msgstr "Lisätiedot"
@@ -1094,9 +1100,6 @@ msgstr ""
 "* Tunnus on voimassa valitsemastasi alkamispäivästä lähtien, kun "
 "maksusuoritus on hyväksytty"
 
-msgid "Source: Transport register, Traficom"
-msgstr "Lähde: Liikenneasioidenrekisteri, Traficom"
-
 msgid "Parking permit expiration date"
 msgstr "Pysäköintitunnuksen päättymispäivä"
 
@@ -1125,12 +1128,11 @@ msgstr "Palaute"
 msgid "Customer service contact info"
 msgstr "Asiakaspalvelu ja yhteystiedot"
 
-msgid ""
-"Your parking permit will expire soon. You can renew your permit by logging "
-"in to the service again."
-msgstr ""
-"Pysäköintitunnuksesi voimassaoloaika päättyy lähiaikoina. Voit uusia "
-"tunnuksen kirjautumalla palveluun"
+msgid "Your parking permit expires at"
+msgstr "Pysäköintitunnuksesi voimassaoloaika päättyy"
+
+msgid "You can renew your permit by logging in to the service again."
+msgstr "Voit uusia tunnuksen kirjautumalla palveluun."
 
 msgid "Thank you for your order!"
 msgstr "Kiitos tilauksestasi!"
@@ -1165,9 +1167,6 @@ msgstr ""
 
 msgid "Total refundable amount"
 msgstr "Palautettava summa yhteensä"
-
-msgid "incl. VAT"
-msgstr "sis. ALV"
 
 msgid ""
 "You are entitled to a refund and it has been registered. You will receive a "

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-13 08:15+0200\n"
+"POT-Creation-Date: 2025-05-13 07:26+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -208,6 +208,9 @@ msgstr "Du kan ha maximalt %(max_allowed_permit)s tillstånd."
 msgid "You can buy permit only for address %(primary_address)s."
 msgstr "Du kan endast köpa tillstånd för adressen %(primary_address)s."
 
+msgid "Source: Transport register, Traficom"
+msgstr "Källä: Trafik- och transportregistret, Traficom"
+
 msgid "Forbidden"
 msgstr "Förbjuden"
 
@@ -336,6 +339,9 @@ msgstr "Återbetalning"
 
 msgid "Refund ID"
 msgstr "Återbetalning ID"
+
+msgid "incl. VAT"
+msgstr "inkl. MOMS"
 
 msgid "Extra info"
 msgstr "Ytterligare uppgifter"
@@ -1094,9 +1100,6 @@ msgstr ""
 "* Parkeringpermit är i kraft från den valda startdatum, när betalningen är "
 "godkännt"
 
-msgid "Source: Transport register, Traficom"
-msgstr "Källä: Trafik- och transportregistret, Traficom"
-
 msgid "Parking permit expiration date"
 msgstr "Tillståndet upphör att gälla"
 
@@ -1125,12 +1128,11 @@ msgstr "Ge respons"
 msgid "Customer service contact info"
 msgstr "Kundtjänst kontaktuppgifter"
 
-msgid ""
-"Your parking permit will expire soon. You can renew your permit by logging "
-"in to the service again."
-msgstr ""
-"Ditt parkeringstillstånd går snart ut. Du kan förnya ditt tillstånd genom "
-"att logga in på tjänsten."
+msgid "Your parking permit expires at"
+msgstr "Ditt parkeringstillstånd går ut vid"
+
+msgid "You can renew your permit by logging in to the service again."
+msgstr "Du kan förnya ditt tillstånd genom att logga in på tjänsten."
 
 msgid "Thank you for your order!"
 msgstr "Tack för din beställning!"
@@ -1169,9 +1171,6 @@ msgstr ""
 
 msgid "Total refundable amount"
 msgstr "Totalt återbetalningsbart belopp"
-
-msgid "incl. VAT"
-msgstr "inkl. MOMS"
 
 msgid ""
 "You are entitled to a refund and it has been registered. You will receive a "

--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -72,9 +72,10 @@ def automatic_expiration_of_permits():
 def automatic_expiration_remind_notification_of_permits():
     logger.info("Automatically sending remind notifications for permits started...")
     count = 0
-    now = tz.localdate(tz.now())
+    current_date = tz.localdate(tz.now())
     expiring_permits = ParkingPermit.objects.filter(
-        end_time__lt=now + relativedelta(weeks=1),
+        Q(end_time__date=current_date + relativedelta(weeks=1))
+        | Q(end_time__date=current_date + relativedelta(days=1)),
         status=ParkingPermitStatus.VALID,
         contract_type=ContractType.FIXED_PERIOD,
     )

--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -134,7 +134,7 @@ class CustomerPermit:
         prev_active_temp_vehicles = list(active_temp_vehicles)
         active_temp_vehicles.update(is_active=False)
         for temp_vehicle in prev_active_temp_vehicles:
-            ParkingPermitEventFactory.make_add_temporary_vehicle_event(
+            ParkingPermitEventFactory.make_remove_temporary_vehicle_event(
                 permit, temp_vehicle, created_by=self.customer.user
             )
         sync_with_parkkihubi(permit)

--- a/parking_permits/forms.py
+++ b/parking_permits/forms.py
@@ -7,7 +7,6 @@ from django.contrib.postgres.forms import SimpleArrayField
 from django.db import models
 from django.db.models import OuterRef, Q, Subquery, Value
 from django.db.models.functions import Concat
-from django.utils import timezone
 
 from parking_permits.models import (
     Address,
@@ -137,8 +136,6 @@ class PermitSearchForm(SearchFormBase):
         if not q:
             return self.get_empty_queryset()
 
-        now = timezone.now()
-
         fields = [
             "vehicle__registration_number",
             "temp_vehicles__vehicle__registration_number",
@@ -170,8 +167,6 @@ class PermitSearchForm(SearchFormBase):
                 TemporaryVehicle.objects.filter(
                     parkingpermit__pk=OuterRef("pk"),
                     is_active=True,
-                    start_time__lte=now,
-                    end_time__gte=now,
                 ).values("vehicle__registration_number")[:1]
             )
         ).filter(query)

--- a/parking_permits/templates/emails/expiration_remind.html
+++ b/parking_permits/templates/emails/expiration_remind.html
@@ -5,7 +5,8 @@
 
 {% block content %}
     <p>
-        {% translate "Your parking permit will expire soon. You can renew your permit by logging in to the service again." %}
+        {% translate "Your parking permit expires at" %}: {{ permit.end_time|date:"j.n.Y, H:i" }}
+        {% translate "You can renew your permit by logging in to the service again." %}
     </p>
 {% include "emails/_permit_info.html" %}
 {% endblock %}

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -487,7 +487,7 @@ class ParkingZoneTestCase(TestCase):
         self.assertEqual(total_quantity, 10)
 
     @freeze_time(timezone.make_aware(datetime(2024, 1, 1)))
-    def test_active_temporary_vehicles_active_in_time_range(self):
+    def test_active_temporary_vehicles_active(self):
         vehicle = TemporaryVehicleFactory(
             start_time=datetime(2023, 12, 20),
             end_time=datetime(2024, 1, 29),
@@ -503,17 +503,6 @@ class ParkingZoneTestCase(TestCase):
             start_time=datetime(2023, 12, 20),
             end_time=datetime(2024, 1, 29),
             is_active=False,
-        )
-        permit = ParkingPermitFactory()
-        permit.temp_vehicles.add(vehicle)
-        self.assertEqual(permit.active_temporary_vehicle, None)
-
-    @freeze_time(timezone.make_aware(datetime(2024, 1, 1)))
-    def test_active_temporary_vehicles_not_in_time_range(self):
-        vehicle = TemporaryVehicleFactory(
-            start_time=datetime(2024, 1, 3),
-            end_time=datetime(2024, 1, 29),
-            is_active=True,
         )
         permit = ParkingPermitFactory()
         permit.temp_vehicles.add(vehicle)

--- a/parking_permits/tests/test_cron.py
+++ b/parking_permits/tests/test_cron.py
@@ -430,7 +430,19 @@ class AutomaticExpirationRemindPermitNotificationTestCase(TestCase):
         )
         ParkingPermitFactory(
             customer=self.customer,
+            end_time=datetime(2023, 4, 5, tzinfo=dt_tz.utc),
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.FIXED_PERIOD,
+        )
+        ParkingPermitFactory(
+            customer=self.customer,
             end_time=datetime(2023, 4, 6, tzinfo=dt_tz.utc),
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.FIXED_PERIOD,
+        )
+        ParkingPermitFactory(
+            customer=self.customer,
+            end_time=datetime(2023, 4, 7, tzinfo=dt_tz.utc),
             status=ParkingPermitStatus.VALID,
             contract_type=ContractType.FIXED_PERIOD,
         )
@@ -470,7 +482,7 @@ class AutomaticExpirationRemindPermitNotificationTestCase(TestCase):
     def test_automatic_expiration_remind_targets(self, mock_method):
         mock_method.return_value = None
         valid_permits = ParkingPermit.objects.filter(status=ParkingPermitStatus.VALID)
-        self.assertEqual(valid_permits.count(), 5)
+        self.assertEqual(valid_permits.count(), 7)
         expiring_permits = automatic_expiration_remind_notification_of_permits()
         self.assertEqual(expiring_permits.count(), 2)
 

--- a/parking_permits/tests/test_customer_permit.py
+++ b/parking_permits/tests/test_customer_permit.py
@@ -83,13 +83,15 @@ class RemoveTemporaryVehicleTestCase(TestCase):
 class AddTemporaryVehicleTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.permit = ParkingPermitFactory(
-            status=VALID,
-            primary_vehicle=True,
-        )
         cls.vehicle = VehicleFactory()
         cls.start_time = tz.now()
         cls.end_time = cls.start_time + timedelta(days=7)
+        cls.permit = ParkingPermitFactory(
+            status=VALID,
+            primary_vehicle=True,
+            start_time=cls.start_time,
+            end_time=cls.end_time,
+        )
 
     def test_add_temporary_vehicle(self):
         self.assertTrue(


### PR DESCRIPTION
## Description

Updates:
- Remove dates from active temporary vehicle (SHPPWS-45)
- Prevent temporary vehicle end time from being more than permit end time (SHPPWS-81)
- Call correct temporary vehicle event function (SHPPWS-62)
- Send permit expiration remind notification only when the permit has exactly 1 week or 1 day left (SHPPWS-70)
- Add permit end time to expiration remind email-template (SHPPWS-70)
- Update fi/sv-translations (SHPPWS-70)

It is now also possible to remove a temporary vehicle that is set to start in the future (SHPPWS-73).
Also temporary vehicle emails that have future temporary vehicle dates render now correctly (SHPPWS-47/SHPPWS-105).

Refs: SHPPWS-45, SHPPWS-81, SHPPWS-62, SHPPWS-70, SHPPWS-105, SHPPWS-73, SHPPWS-47, SHPPWS-105
