### PR TITLE
SHPPWS-113: Automatically deactivate expired temporary vehicles

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -1527,19 +1527,8 @@ def add_temporary_vehicle(
 @convert_kwargs_to_snake_case
 @transaction.atomic
 def remove_temporary_vehicle(obj, info, permit_id):
-    request = info.context["request"]
     permit = ParkingPermit.objects.get(id=permit_id)
-    active_temp_vehicles = permit.temp_vehicles.filter(is_active=True)
-    prev_active_temp_vehicles = list(active_temp_vehicles)
-
-    active_temp_vehicles.update(is_active=False)
+    permit.remove_temporary_vehicle()
     sync_with_parkkihubi(permit)
-
-    for temp_vehicle in prev_active_temp_vehicles:
-        ParkingPermitEventFactory.make_remove_temporary_vehicle_event(
-            permit, temp_vehicle, request.user
-        )
-
     send_permit_email(PermitEmailType.TEMP_VEHICLE_DEACTIVATED, permit)
-
     return {"success": True}

--- a/parking_permits/cron.py
+++ b/parking_permits/cron.py
@@ -5,7 +5,11 @@ from django.db.models import Q
 from django.utils import timezone as tz
 
 from parking_permits.customer_permit import CustomerPermit
-from parking_permits.models import Announcement, Customer, ParkingPermit
+from parking_permits.models import (
+    Announcement,
+    Customer,
+    ParkingPermit,
+)
 from parking_permits.models.order import SubscriptionCancelReason
 from parking_permits.models.parking_permit import (
     ContractType,
@@ -105,6 +109,22 @@ def automatic_remove_obsolete_customer_data():
 
 
 def automatic_syncing_of_permits_to_parkkihubi():
+    logger.info("Automatically syncing permits to Parkkihubi started...")
+
+    # Automatically deactivate temporary vehicles that are in the past
+    temp_vehicle_permits = ParkingPermit.objects.filter(
+        temp_vehicles__is_active=True,
+        temp_vehicles__end_time__lt=tz.localtime(tz.now()),
+    )
+    for permit in temp_vehicle_permits:
+        permit.remove_temporary_vehicle()
+        sync_with_parkkihubi(permit)
+        send_permit_email(PermitEmailType.TEMP_VEHICLE_DEACTIVATED, permit)
+        logger.info(
+            f"Permit {permit.pk} temporary vehicle deactivated "
+            f"because it is in the past."
+        )
+
     statuses_to_sync = [
         ParkingPermitStatus.CLOSED,
         ParkingPermitStatus.VALID,
@@ -112,5 +132,11 @@ def automatic_syncing_of_permits_to_parkkihubi():
     permits = ParkingPermit.objects.filter(
         synced_with_parkkihubi=False, status__in=statuses_to_sync
     )
+    permit_count = permits.count()
     for permit in permits:
         sync_with_parkkihubi(permit)
+
+    logger.info(
+        "Automatically syncing permits to Parkkihubi completed. "
+        f"{permit_count} permits synced."
+    )

--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -130,13 +130,7 @@ class CustomerPermit:
     def remove_temporary_vehicle(self, permit_id):
         permit_details = self._get_permit(permit_id)
         permit = permit_details[0]
-        active_temp_vehicles = permit.temp_vehicles.filter(is_active=True)
-        prev_active_temp_vehicles = list(active_temp_vehicles)
-        active_temp_vehicles.update(is_active=False)
-        for temp_vehicle in prev_active_temp_vehicles:
-            ParkingPermitEventFactory.make_remove_temporary_vehicle_event(
-                permit, temp_vehicle, created_by=self.customer.user
-            )
+        permit.remove_temporary_vehicle()
         sync_with_parkkihubi(permit)
         send_permit_email(PermitEmailType.TEMP_VEHICLE_DEACTIVATED, permit)
         return True

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -959,6 +959,17 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
         return temp_vehicle
 
+    def remove_temporary_vehicle(self):
+        """Remove active temporary vehicle from the permit."""
+        active_temp_vehicles = self.temp_vehicles.filter(is_active=True)
+        prev_active_temp_vehicles = list(active_temp_vehicles)
+        active_temp_vehicles.update(is_active=False)
+        for temp_vehicle in prev_active_temp_vehicles:
+            ParkingPermitEventFactory.make_remove_temporary_vehicle_event(
+                self, temp_vehicle
+            )
+        return True
+
     def is_temporary_vehicle_limit_exceeded(self, user) -> bool:
         """Check limit of temporary vehicles.
         A user can only create max 2 temp vehicles over 12 months."""

--- a/parking_permits/tests/test_resolver_utils.py
+++ b/parking_permits/tests/test_resolver_utils.py
@@ -505,9 +505,7 @@ class TestCreateRefund:
         assert refunds[0].amount == 180
 
     @pytest.mark.django_db()
-    def test_new_refund_with_permit_extension_request(
-        self, zone
-    ):
+    def test_new_refund_with_permit_extension_request(self, zone):
         with freeze_time("2024-3-26"):
             start_time = timezone.make_aware(datetime(2024, 1, 1))
             end_time = timezone.make_aware(datetime(2024, 12, 31))
@@ -565,9 +563,7 @@ class TestCreateRefund:
             assert refund.vat_amount == pytest.approx(Decimal(34.84), delta)
 
     @pytest.mark.django_db()
-    def test_multiple_vat_refunds_with_permit_extension_request(
-        self, zone
-    ):
+    def test_multiple_vat_refunds_with_permit_extension_request(self, zone):
         with freeze_time("2024-3-26"):
             start_time = timezone.make_aware(datetime(2024, 1, 1))
             end_time = timezone.make_aware(datetime(2024, 12, 31))
@@ -636,9 +632,7 @@ class TestCreateRefund:
             assert second_refund.vat_amount == pytest.approx(Decimal(24.38), delta)
 
     @pytest.mark.django_db()
-    def test_new_refund_with_permit_extension_request_multiple_products(
-        self, zone
-    ):
+    def test_new_refund_with_permit_extension_request_multiple_products(self, zone):
         with freeze_time("2024-3-26"):
             start_time = timezone.make_aware(datetime(2024, 1, 1))
             end_time = timezone.make_aware(datetime(2024, 6, 30))
@@ -797,9 +791,7 @@ class TestCreateRefund:
             assert second_refund.vat_amount == pytest.approx(Decimal(52.83), delta)
 
     @pytest.mark.django_db()
-    def test_new_refund_with_permit_low_emission_vehicle(
-        self, zone
-    ):
+    def test_new_refund_with_permit_low_emission_vehicle(self, zone):
         with freeze_time("2024-3-26"):
             start_time = timezone.make_aware(datetime(2024, 1, 1))
             end_time = timezone.make_aware(datetime(2024, 12, 31))
@@ -930,9 +922,7 @@ class TestCreateRefund:
             assert refund.vat_amount == pytest.approx(Decimal(34.84), delta)
 
     @pytest.mark.django_db()
-    def test_multiple_vat_refunds_with_permit_vehicle_change(
-        self, zone
-    ):
+    def test_multiple_vat_refunds_with_permit_vehicle_change(self, zone):
         with freeze_time("2024-3-26"):
             start_time = timezone.make_aware(datetime(2024, 1, 1))
             end_time = timezone.make_aware(datetime(2024, 12, 31))
@@ -1024,9 +1014,7 @@ class TestCreateRefund:
             assert second_refund.vat_amount == pytest.approx(Decimal(18.29), delta)
 
     @pytest.mark.django_db()
-    def test_new_refund_with_permit_vehicle_change_multiple_products(
-        self, zone
-    ):
+    def test_new_refund_with_permit_vehicle_change_multiple_products(self, zone):
         with freeze_time("2024-3-26"):
             start_time = timezone.make_aware(datetime(2024, 1, 1))
             end_time = timezone.make_aware(datetime(2024, 6, 30))


### PR DESCRIPTION
## Description

Automatically deactivate expired temporary vehicles
Use "automatic_syncing_of_permits_to_parkkihubi"-cronjob for this.

Refs: SHPPWS-113

## How Has This Been Tested?

Via unit tests.

