### PR TITLE
SHPPWS-109: Show full permit detail history

### DIFF
--- a/parking_permits/admin_resolvers.py
+++ b/parking_permits/admin_resolvers.py
@@ -224,10 +224,9 @@ def resolve_permit_detail(obj, info, permit_id):
 
 @PermitDetail.field("changeLogs")
 def resolve_permit_detail_history(permit, info):
-    events = ParkingPermitEvent.objects.filter(parking_permit=permit).order_by(
+    return ParkingPermitEvent.objects.filter(parking_permit=permit).order_by(
         "-created_at"
-    )[:10]
-    return events
+    )
 
 
 @query.field("zones")


### PR DESCRIPTION
## Description

For some legacy reason, permit history was limited to 10 rows.
Remove this limitation and always show full permit detail history.

Refs: SHPPWS-109

