### PR TITLE
SWPPWS-115: centrally enforce unique customer-vehicle-pairs

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -19,7 +19,7 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import gettext_noop
 from helsinki_gdpr.models import SerializableMixin
 
-from ..exceptions import PermitCanNotBeEnded, TemporaryVehicleValidationError
+from ..exceptions import DuplicatePermit, PermitCanNotBeEnded, TemporaryVehicleValidationError
 from ..utils import (
     calc_net_price,
     calc_vat_price,
@@ -541,6 +541,34 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         3. PERMIT_EXTENSIONS_ENABLED flag is True.
         """
         return self._can_extend_parking_permit(is_date_restriction=False)
+    
+    def save(self, *args, **kwargs):
+        # Enforce unique customer-vehicle-pair depending on the status,
+        # duplicate customer-vehicle-pairs are allowed only for 
+        # permits with cancelled/closed status
+        non_duplicable_statuses = [
+            ParkingPermitStatus.VALID, 
+            ParkingPermitStatus.PAYMENT_IN_PROGRESS, 
+            ParkingPermitStatus.DRAFT, 
+            ParkingPermitStatus.PRELIMINARY
+        ]
+
+        duplicate_query = ParkingPermit.objects.exclude(id=self.id).filter(
+            customer_id = self.customer_id,
+            vehicle__registration_number = self.vehicle.registration_number,
+            # Pre-existing cancelled/closed permits do not contribute
+            # towards potential duplicates
+            status__in = non_duplicable_statuses
+        )
+
+        # If the permit being saved is cancelled/closed, we can
+        # short-circuit to avoid db-hit/query-evaluation 
+        # as those statuses will never break the constraint
+        check_for_duplicates = self.status in non_duplicable_statuses
+        if check_for_duplicates and duplicate_query.exists():
+            raise DuplicatePermit(_("Permit for a given vehicle already exist."))
+        
+        return super().save(*args, **kwargs)
 
     def _can_extend_parking_permit(self, *, is_date_restriction=True):
         if not all(

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -10,6 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from freezegun import freeze_time
 
 from parking_permits.exceptions import (
+    DuplicatePermit,
     PermitCanNotBeEnded,
     ProductCatalogError,
     TemporaryVehicleValidationError,
@@ -985,6 +986,19 @@ class ParkingZoneTestCase(TestCase):
 
 
 class ParkingPermitTestCase(TestCase):
+
+    duplicable_statuses = [
+        ParkingPermitStatus.CANCELLED, 
+        ParkingPermitStatus.CLOSED, 
+    ]
+    
+    non_duplicable_statuses = [
+        ParkingPermitStatus.VALID, 
+        ParkingPermitStatus.PAYMENT_IN_PROGRESS, 
+        ParkingPermitStatus.DRAFT, 
+        ParkingPermitStatus.PRELIMINARY
+    ]
+
     def setUp(self):
         self.permit = ParkingPermitFactory()
 
@@ -1674,3 +1688,73 @@ class ParkingPermitTestCase(TestCase):
         )
 
         self.assertTrue(ParkingPermitEvent.objects.filter(created_by=user).exists())
+
+    def test_saving_duplicate_permit_raises(self):
+        customer = CustomerFactory()
+        vehicle = VehicleFactory()
+
+        for status_for_preexisting in self.non_duplicable_statuses:
+            preexisting_permit = ParkingPermitFactory(
+                customer=customer,
+                vehicle=vehicle,
+                status=status_for_preexisting
+            )
+
+            for status_for_new in self.non_duplicable_statuses:
+                with self.assertRaises(DuplicatePermit):
+                    ParkingPermitFactory(
+                        customer=customer,
+                        vehicle=vehicle,
+                        status=status_for_new
+                    )
+            
+            # Cleanup for the next pre-existing status
+            preexisting_permit.delete()
+
+    def test_saving_closed_or_cancelled_permit_does_not_raise(self):
+        customer = CustomerFactory()
+        vehicle = VehicleFactory()
+
+        for status_for_preexisting in ParkingPermitStatus.values:
+            preexisting_permit = ParkingPermitFactory(
+                customer=customer,
+                vehicle=vehicle,
+                status=status_for_preexisting
+            )
+
+            for status_for_new in self.duplicable_statuses:
+                new_permit = ParkingPermitFactory(
+                    customer=customer,
+                    vehicle=vehicle,
+                    status=status_for_new
+                )
+                # Cleanup to prevent multiple simultaneous new permits
+                new_permit.delete()
+
+            # Cleanup for the next pre-existing status
+            preexisting_permit.delete()
+    
+    def test_preexisting_closed_or_cancelled_does_not_contribute_to_duplicates(self):
+        customer = CustomerFactory()
+        vehicle = VehicleFactory()
+
+        for status_for_preexisting in self.duplicable_statuses:
+            preexisting_permit = ParkingPermitFactory(
+                customer=customer,
+                vehicle=vehicle,
+                status=status_for_preexisting
+            )
+
+            for status_for_new in ParkingPermitStatus.values:
+                new_permit=ParkingPermitFactory(
+                    customer=customer,
+                    vehicle=vehicle,
+                    status=status_for_new
+                )
+                # Cleanup to prevent multiple simultaneous new permits
+                new_permit.delete()
+
+            # Cleanup for the next pre-existing status
+            preexisting_permit.delete()
+
+        # No exceptions raised by now => all good

--- a/parking_permits/tests/test_customer_permit.py
+++ b/parking_permits/tests/test_customer_permit.py
@@ -276,7 +276,7 @@ class GetCustomerPermitTestCase(TestCase):
             status=DRAFT,
             primary_vehicle=False,
             parking_zone=self.zone,
-            vehicle=self.vehicle_b,
+            vehicle=self.vehicle_c,
             start_type=IMMEDIATELY,
             start_time=previous_day(),
         )


### PR DESCRIPTION
Extend save() in ParkingPermit-model in order to enforce unique customer-vehicle-pairs for certain statuses in a centralized way. Duplicates are still allowed for CANCELLED- and CLOSED-statuses.