### PR TITLE
SHPPWS-101: cancel old unpaid orders via cron

### DIFF
--- a/parking_permits/management/commands/cancel_old_unpaid_permits.py
+++ b/parking_permits/management/commands/cancel_old_unpaid_permits.py
@@ -1,0 +1,64 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone as tz
+
+from parking_permits.models.order import Order, OrderStatus
+from parking_permits.models.parking_permit import ParkingPermit, ParkingPermitStatus
+
+CANCELLED = ParkingPermitStatus.CANCELLED
+PAYMENT_IN_PROGRESS = ParkingPermitStatus.PAYMENT_IN_PROGRESS
+
+
+class Command(BaseCommand):
+    help = "Cancel permits and their latest orders for permits that"
+    "have been stuck in PAYMENT_IN_PROGRESS-status for long enough."
+    "(controlled by TALPA_ORDER_PAYMENT_WEBHOOK_WAIT_BUFFER_MINS-setting)"
+
+    def handle(self, *args, **options):
+        unpaid_permits = ParkingPermit.objects.filter(status=PAYMENT_IN_PROGRESS)
+
+        payment_wait_time_buffer = settings.TALPA_ORDER_PAYMENT_WEBHOOK_WAIT_BUFFER_MINS
+
+        permits_to_update = []
+        orders_to_update = []
+
+        for permit in unpaid_permits:
+            latest_order = permit.latest_order
+            if not latest_order:
+                continue
+
+            old_enough_to_cancel = (
+                tz.localtime(
+                    latest_order.talpa_last_valid_purchase_time
+                    + tz.timedelta(minutes=payment_wait_time_buffer)
+                )
+                < tz.localtime()
+            )
+
+            if old_enough_to_cancel:
+                permit.status = CANCELLED
+                permits_to_update.append(permit)
+
+                latest_order.status = OrderStatus.CANCELLED
+                orders_to_update.append(latest_order)
+
+        with transaction.atomic():
+            # NOTE: bulk_update() DOES NOT call save() internally,
+            # but this is actually desirable here:
+            # - the only custom logic in ParkingPermit.save() is used
+            # to check for duplicate permits
+            # - we are updating permits to CANCELLED-status, meaning that
+            # it's impossible to break the constraint as duplicates are allowed
+            # for permits with CANCELLED-status. We're better off
+            # (performance-wise) skipping the check altogether.
+            ParkingPermit.objects.bulk_update(
+                objs=permits_to_update,
+                fields=["status"],
+                batch_size=200,
+            )
+            Order.objects.bulk_update(
+                objs=orders_to_update,
+                fields=["status"],
+                batch_size=200,
+            )


### PR DESCRIPTION
Implement a management command for cancelling permits with 'payment in progress'-status which have latest orders that are old enough (TALPA_ORDER_PAYMENT_WEBHOOK_WAIT_BUFFER_MINS-setting). The latest orders of such permits are also cancelled.
