### PR TITLE
SHPPWS-109: sync month count when ending permit

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -875,6 +875,8 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
             )
 
         self.end_time = end_time
+        self.month_count = diff_months_ceil(self.start_time, end_time)
+
         if (
             end_type == ParkingPermitEndType.IMMEDIATELY
             or end_type == ParkingPermitEndType.PREVIOUS_DAY_END

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -419,6 +419,8 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         now = timezone.now()
         diff_months = diff_months_ceil(self.start_time, now)
         if self.is_fixed_period:
+            # self.month_count acts as an upper bound for diff_months
+            # which ensures nonnegative months_left
             return min(self.month_count, diff_months)
         return diff_months
 


### PR DESCRIPTION
Permit month_count may end up out of sync when ending permits, causing erroneous refunds if the permit is made valid again and then ended again. This is due to get_unused_order_items_for_order() using too early unused_start_date due to month_count acting as an upper bound for months_used when calculating next_period_start_time.
