### PR TITLE
SHPPWS-139: fix erroneous date calculation when refunding

### DIFF
--- a/parking_permits/models/order.py
+++ b/parking_permits/models/order.py
@@ -276,7 +276,7 @@ class OrderManager(SerializableMixin.SerializableManager):
                     "Cannot create renewal order for open ended permits"
                 )
 
-            start_date = tz.localdate(permit.next_period_start_time)
+            start_date = permit.next_period_start_time
             end_date = tz.localdate(permit.end_time)
             date_ranges.append([start_date, end_date])
 
@@ -319,7 +319,7 @@ class OrderManager(SerializableMixin.SerializableManager):
             vehicle = permit.next_vehicle if permit.next_vehicle else permit.vehicle
             new_order.vehicles.append(vehicle.registration_number)
             new_order.save()
-            start_date = tz.localdate(permit.next_period_start_time)
+            start_date = permit.next_period_start_time
             end_date = tz.localdate(permit.end_time)
             if start_date >= end_date:
                 # permit already ended or will be ended after current month period

--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -473,7 +473,8 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
     @property
     def next_period_start_time(self):
-        return self.start_time + relativedelta(months=self.months_used)
+        start_time = timezone.localdate(self.start_time)
+        return start_time + relativedelta(months=self.months_used)
 
     @property
     def can_be_refunded(self):
@@ -731,7 +732,7 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         new_products = new_zone.products.for_resident()
         is_secondary = not self.primary_vehicle
         if self.is_open_ended:
-            start_date = timezone.localdate(self.next_period_start_time)
+            start_date = self.next_period_start_time
             end_date = start_date + relativedelta(months=1, days=-1)
             previous_product = previous_products.get_for_date(start_date)
             previous_price = previous_product.get_modified_unit_price(
@@ -769,7 +770,7 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
 
         if self.is_fixed_period:
             # price change affected date range and products
-            start_date = timezone.localdate(self.next_period_start_time)
+            start_date = self.next_period_start_time
             end_date = timezone.localdate(self.end_time)
             previous_product_iter = previous_products.for_date_range(
                 start_date, end_date
@@ -1070,7 +1071,7 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
     def get_unused_order_items_for_order(self, order):
         from .order import OrderStatus
 
-        unused_start_date = timezone.localdate(self.next_period_start_time)
+        unused_start_date = self.next_period_start_time
 
         order_items = order.order_items.filter(
             end_time__date__gte=unused_start_date,

--- a/parking_permits/tests/test_resolver_utils.py
+++ b/parking_permits/tests/test_resolver_utils.py
@@ -1301,12 +1301,6 @@ class TestCreateRefund:
 
         assert refunds == []
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Verify a bug concerning the wrong "
-        "order of operations when adding months before timezone-conversion "
-        "when computing unused_start_date during refund-calculation",
-    )
     @pytest.mark.django_db()
     def test_auto_expiring_single_calendar_month_fixed_period_permit_does_not_refund(
         self, zone


### PR DESCRIPTION
## Description

When computing `unused_start_date` during refund-calculation, the used months of the permit are added into the permits start time that has not yet been converted out from the UTC-timezone. This causes an erroneous `unused_start_date` if: 

- the permits start time (in Europe/Helsinki-timezone) is in the beginning of the month so that it ends up in the end of the previous month when converted into UTC
- the previous month has a different amount of days than the month of the permits start time (in Europe/Helsinki-timezone)

These will cause the month-adding with `relativedelta` to add a wrong amount of days, which in turn causes erroneous refunds. 

This is fixed by performing the timezone-conversion before adding the used months into the permits start time.

## How Has This Been Tested?

A test with xfail confirming the bug has been implemented in the first commit of this PR. The actual fix is in a separate commit in order to leave a deliberate mark in the version history that the test actually fails without the fix.