### PR TITLE
SHPPWS-161: Remove dnf update step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ USER root
 
 COPY requirements.txt .
 
-RUN dnf update -y && dnf install -y \
+RUN dnf install -y \
     nmap-ncat \
     gettext \
     postgresql \


### PR DESCRIPTION
## Description

`dnf` is trying to remove or update protected packages. This often happens if dependencies conflict or if the base image is already up-to-date and `dnf update -y` tries to change core packages.

Remove the `dnf update -y` step entirely. The base image should already be updated, and running upgrades in containers is not recommended.

## Context

Refs: SHPPWS-161

## How Has This Been Tested?

`docker build` works again normally after this change.