### PR TITLE
SHPPWS-238: remove user on anonymization

### DIFF
--- a/parking_permits/models/customer.py
+++ b/parking_permits/models/customer.py
@@ -413,13 +413,9 @@ class Customer(SerializableMixin, TimestampedModelMixin):
             if hasattr(self, "driving_licence"):
                 self.driving_licence.delete()
 
-            # Anonymize User if exists
+            # Delete User if exists
             if self.user:
-                self.user.first_name = ""
-                self.user.last_name = ""
-                self.user.email = f"anonymized-{self.pk}@anonymized.invalid"
-                self.user.username = f"anonymized-{self.pk}"
-                self.user.save()
+                self.user.delete()
 
             # Clear Order.vehicles ArrayField (denormalized registration numbers)
             self.orders.update(vehicles=[])

--- a/parking_permits/models/customer.py
+++ b/parking_permits/models/customer.py
@@ -13,6 +13,8 @@ from django.utils.translation import gettext_lazy as _
 from helsinki_gdpr.models import SerializableMixin
 
 from parking_permits.exceptions import CustomerCannotBeAnonymizedError
+from parking_permits.models.announcement import Announcement
+from parking_permits.models.product import Accounting, Product
 
 from ..services.traficom import Traficom
 from .common import SourceSystem
@@ -415,6 +417,30 @@ class Customer(SerializableMixin, TimestampedModelMixin):
 
             # Delete User if exists
             if self.user:
+                # Avoid circular imports
+                from parking_permits.models.order import Order, Subscription
+
+                # null relevant (protected) created_by/modified_by foreign keys
+                models_with_protected_user_reference = (
+                    Order,
+                    Subscription,
+                    Refund,
+                    ParkingPermitEvent,
+                    Product,
+                    Announcement,
+                    Accounting,
+                )
+
+                Refund.objects.filter(accepted_by=self.user).update(accepted_by=None)
+
+                for model_class in models_with_protected_user_reference:
+                    model_class.objects.filter(created_by=self.user).update(
+                        created_by=None
+                    )
+                    model_class.objects.filter(modified_by=self.user).update(
+                        modified_by=None
+                    )
+
                 self.user.delete()
 
             # Clear Order.vehicles ArrayField (denormalized registration numbers)

--- a/parking_permits/models/customer.py
+++ b/parking_permits/models/customer.py
@@ -326,6 +326,32 @@ class Customer(SerializableMixin, TimestampedModelMixin):
 
         return can_be_anonymized
 
+    def _remove_vehicle_users_related_by_national_id_number(self):
+        # Remove VehicleUsers related to national_id_number
+        # if national_id_number is not null
+        if self.national_id_number is None:
+            return
+        # Collect vehicles, these are needed for
+        # VehicleUser-removal which in turn needs the
+        # pre-anonymization national_id_number to allow removing
+        # only those VehicleUsers that are linked to the customer.
+        vehicle_ids_linked_to_permits = self.permits.values_list(
+            "vehicle_id", flat=True
+        ).union(
+            self.permits.filter(next_vehicle_id__isnull=False).values_list(
+                "next_vehicle_id", flat=True
+            )
+        )
+
+        # Delete VehicleUsers which are linked to these vehicles
+        # and match the customers national_id_number.
+        # Note that if vehicle_ids_linked_to_permits is empty,
+        # then delete() is ran against an empty queryset => no-op.
+        VehicleUser.objects.filter(
+            vehicles__in=vehicle_ids_linked_to_permits,
+            national_id_number=self.national_id_number,
+        ).delete()
+
     def anonymize_all_data(self):
         """Anonymize all customer related data for GDPR compliance.
 
@@ -336,26 +362,8 @@ class Customer(SerializableMixin, TimestampedModelMixin):
             raise CustomerCannotBeAnonymizedError
 
         with transaction.atomic():
-            # Collect vehicles, these are needed for
-            # VehicleUser-removal which in turn needs the
-            # pre-anonymization national_id_number to allow removing
-            # only those VehicleUsers that are linked to the customer.
-            vehicle_ids_linked_to_permits = self.permits.values_list(
-                "vehicle_id", flat=True
-            ).union(
-                self.permits.filter(next_vehicle_id__isnull=False).values_list(
-                    "next_vehicle_id", flat=True
-                )
-            )
-
-            # Delete VehicleUsers which are linked to these vehicles
-            # and match the customers national_id_number.
-            # Note that if vehicle_ids_linked_to_permits is empty,
-            # then delete() is ran against an empty queryset => no-op.
-            VehicleUser.objects.filter(
-                vehicles__in=vehicle_ids_linked_to_permits,
-                national_id_number=self.national_id_number,
-            ).delete()
+            # Ran first due to needing pre-anonymization national_id_number
+            self._remove_vehicle_users_related_by_national_id_number()
 
             # Anonymize Customer fields
             self.first_name = "Anonymized"

--- a/parking_permits/tests/models/test_customer.py
+++ b/parking_permits/tests/models/test_customer.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.db.models import ProtectedError
 from django.test import TestCase
 from django.utils import timezone
 from freezegun import freeze_time
@@ -17,8 +18,10 @@ from parking_permits.models.parking_permit import (
     ParkingPermitEventFactory,
     ParkingPermitStatus,
 )
+from parking_permits.models.product import Accounting
 from parking_permits.models.vehicle import VehicleUser
 from parking_permits.tests.factories.address import AddressFactory
+from parking_permits.tests.factories.announcement import AnnouncementFactory
 from parking_permits.tests.factories.customer import CustomerFactory
 from parking_permits.tests.factories.order import (
     OrderFactory,
@@ -290,7 +293,8 @@ class AnonymizeAllUserDataTestCase(TestCase):
                     self.another_refund.orders.add(self.another_refunded_order)
 
                 self.permit_event = ParkingPermitEventFactory.make_end_permit_event(
-                    permit=self.refunded_permit
+                    permit=self.refunded_permit,
+                    created_by=self.customer.user,
                 )
 
     def _refresh_test_objects(self):
@@ -746,3 +750,353 @@ class TestCannotAnonymizeCustomerErrorTestCase(TestCase):
         # too new modified-timestamp.
         with self.assertRaises(CustomerCannotBeAnonymizedError):
             customer.anonymize_all_data()
+
+
+class AnonymizeUserDeletionProtectionTestCase(TestCase):
+    """
+    Some models inherit UserStampedModelMixin (created_by/modified_by, on_delete=PROTECT),
+    which blocks naive user-deletes. Anonymization must be able to handle these cases.
+    """
+
+    def user_can_still_be_anonymized_and_deleted_helper(
+        self, *, user, related_object, user_link_field
+    ):
+        user_id = user.id
+
+        with freeze_time(timezone.make_aware(datetime(2022, 12, 31, 0, 0, 1))):
+            user.customer.anonymize_all_data()
+
+        # user should be deleted
+        self.assertFalse(User.objects.filter(pk=user_id).exists())
+        # related object should still exist with nulled user_link_field
+        related_object.refresh_from_db()
+        self.assertIsNone(getattr(related_object, user_link_field))
+
+    def test_user_with_created_order_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            order = OrderFactory(customer=customer)
+            order.created_by = user
+            order.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=order, user_link_field="created_by"
+        )
+
+    def test_user_with_modified_order_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            order = OrderFactory(customer=customer)
+            order.modified_by = user
+            order.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=order, user_link_field="modified_by"
+        )
+
+    def test_user_with_accepted_refund_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            refund = RefundFactory()
+            refund.accepted_by = user
+            refund.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=refund, user_link_field="accepted_by"
+        )
+
+    def test_user_with_created_refund_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            refund = RefundFactory()
+            refund.created_by = user
+            refund.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=refund, user_link_field="created_by"
+        )
+
+    def test_user_with_modified_refund_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            refund = RefundFactory()
+            refund.modified_by = user
+            refund.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=refund, user_link_field="modified_by"
+        )
+
+    def test_user_with_created_permit_event_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            permit = ParkingPermitFactory(customer=customer)
+            permit_event = ParkingPermitEventFactory.make_end_permit_event(
+                permit=permit
+            )
+            permit_event.created_by = user
+            permit_event.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=permit_event, user_link_field="created_by"
+        )
+
+    def test_user_with_modified_permit_event_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            permit = ParkingPermitFactory(customer=customer)
+            permit_event = ParkingPermitEventFactory.make_end_permit_event(
+                permit=permit
+            )
+            permit_event.created_by = user
+            permit_event.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=permit_event, user_link_field="modified_by"
+        )
+
+    def test_user_with_created_subscription_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            subscription = SubscriptionFactory()
+            subscription.created_by = user
+            subscription.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=subscription, user_link_field="created_by"
+        )
+
+    def test_user_with_modified_subscription_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            subscription = SubscriptionFactory()
+            subscription.modified_by = user
+            subscription.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=subscription, user_link_field="modified_by"
+        )
+
+    def test_user_with_created_product_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            product = ProductFactory()
+            product.created_by = user
+            product.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=product, user_link_field="created_by"
+        )
+
+    def test_user_with_modified_product_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            product = ProductFactory()
+            product.created_by = user
+            product.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=product, user_link_field="modified_by"
+        )
+
+    def test_user_with_created_announcement_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            announcement = AnnouncementFactory()
+            announcement.created_by = user
+            announcement.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=announcement, user_link_field="created_by"
+        )
+
+    def test_user_with_modified_announcement_can_still_be_anonymized_and_deleted(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            announcement = AnnouncementFactory()
+            announcement.modifed_by = user
+            announcement.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=announcement, user_link_field="modified_by"
+        )
+
+    def test_user_with_created_permit_event_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            permit = ParkingPermitFactory(customer=customer)
+            event = ParkingPermitEventFactory.make_end_permit_event(permit=permit)
+            event.created_by = user
+            event.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_modified_permit_event_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            permit = ParkingPermitFactory(customer=customer)
+            event = ParkingPermitEventFactory.make_end_permit_event(permit=permit)
+            event.modified_by = user
+            event.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_refund_accepted_by_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            refund = RefundFactory()
+            refund.accepted_by = user
+            refund.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_refund_created_by_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            refund = RefundFactory()
+            refund.created_by = user
+            refund.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_refund_modified_by_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            refund = RefundFactory()
+            refund.modified_by = user
+            refund.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_created_order_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            order = OrderFactory()
+            order.created_by = user
+            order.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_modified_order_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            order = OrderFactory()
+            order.modified_by = user
+            order.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_created_subscription_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            subscription = SubscriptionFactory()
+            subscription.created_by = user
+            subscription.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_modified_subscription_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            subscription = SubscriptionFactory()
+            subscription.modified_by = user
+            subscription.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_created_product_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            product = ProductFactory()
+            product.created_by = user
+            product.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_modified_product_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            product = ProductFactory()
+            product.modified_by = user
+            product.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_created_announcement_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            announcement = AnnouncementFactory()
+            announcement.created_by = user
+            announcement.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_modified_announcement_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            announcement = AnnouncementFactory()
+            announcement.modified_by = user
+            announcement.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_created_accounting_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            accounting = Accounting.objects.create()
+            accounting.created_by = user
+            accounting.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_modified_accounting_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            accounting = Accounting.objects.create()
+            accounting.modified_by = user
+            accounting.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()

--- a/parking_permits/tests/models/test_customer.py
+++ b/parking_permits/tests/models/test_customer.py
@@ -1100,3 +1100,33 @@ class AnonymizeUserDeletionProtectionTestCase(TestCase):
 
         with self.assertRaises(ProtectedError):
             user.delete()
+
+
+class AnonymizeNullSsnTestCase(TestCase):
+    def test_null_ssn_does_not_delete_unrelated_null_ssn_vehicle_users(self):
+        """A customer with null national_id_number must not delete VehicleUser
+        rows that also have null national_id_number (those belong to other people)."""
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory(national_id_number=None)
+            permit_vehicle = VehicleFactory()
+            ParkingPermitFactory(customer=customer, vehicle=permit_vehicle)
+
+            # Unrelated vehicle user with null ssn, attached to the same vehicle
+            unrelated_vehicle_user_without_ssn = VehicleUser.objects.create(
+                national_id_number=None
+            )
+            permit_vehicle.users.add(unrelated_vehicle_user_without_ssn)
+
+        with freeze_time(timezone.make_aware(datetime(2022, 12, 31, 0, 0, 1))):
+            customer.anonymize_all_data()
+
+        unrelated_vehicle_user_exists = VehicleUser.objects.filter(
+            id=unrelated_vehicle_user_without_ssn.id
+        ).exists()
+
+        self.assertTrue(
+            unrelated_vehicle_user_exists,
+            "Unrelated VehicleUser with null SSN should not be deleted",
+        )
+        customer.refresh_from_db()
+        self.assertEqual(customer.national_id_number, f"XX-ANON-{customer.pk:06d}")

--- a/parking_permits/tests/models/test_customer.py
+++ b/parking_permits/tests/models/test_customer.py
@@ -2,6 +2,7 @@ from datetime import date, datetime
 from decimal import Decimal
 
 import pytest
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
 from freezegun import freeze_time
@@ -28,6 +29,8 @@ from parking_permits.tests.factories.parking_permit import ParkingPermitFactory
 from parking_permits.tests.factories.product import ProductFactory
 from parking_permits.tests.factories.refund import RefundFactory
 from parking_permits.tests.factories.vehicle import VehicleFactory
+
+User = get_user_model()
 
 
 class TestCustomer(TestCase):
@@ -295,9 +298,6 @@ class AnonymizeAllUserDataTestCase(TestCase):
         self.primary_address.refresh_from_db()
         self.other_address.refresh_from_db()
 
-        if self.create_user:
-            self.customer.user.refresh_from_db()
-
         if self.create_company:
             self.company.refresh_from_db()
             self.company.address.refresh_from_db()
@@ -352,7 +352,7 @@ class AnonymizeAllUserDataTestCase(TestCase):
         )
 
         if self.create_user:
-            pre_anon_data["user_uuid"] = self.customer.user.uuid
+            pre_anon_data["user_id"] = self.customer.user.id
 
         if self.create_permits:
             pre_anon_data["permit"] = self._create_pre_anon_snapshot(
@@ -409,10 +409,9 @@ class AnonymizeAllUserDataTestCase(TestCase):
 
     def run_assertions(self, pre_anon_data):
         self.assert_anonymized_customer_gdpr_fields()
+
         if self.create_user:
-            self.assert_anonymized_user_gdpr_fields(
-                pre_anon_user_uuid=pre_anon_data["user_uuid"]
-            )
+            self.assert_customers_user_is_deleted(user_id=pre_anon_data["user_id"])
 
         self.assert_anonymization_preserves_address_statistical_data(
             address=self.primary_address,
@@ -517,15 +516,10 @@ class AnonymizeAllUserDataTestCase(TestCase):
         self.assertEqual(customer.source_id, "")
         self.assertEqual(customer.is_anonymized, True)
 
-    def assert_anonymized_user_gdpr_fields(self, pre_anon_user_uuid):
-        user = self.customer.user
-        self.assertEqual(user.first_name, "")
-        self.assertEqual(user.last_name, "")
-        self.assertEqual(
-            user.email, f"anonymized-{self.customer.pk}@anonymized.invalid"
-        )
-        self.assertEqual(user.username, f"anonymized-{self.customer.pk}")
-        self.assertEqual(str(user.uuid), pre_anon_user_uuid)
+    def assert_customers_user_is_deleted(self, user_id):
+        user_exists = User.objects.filter(id=user_id).exists()
+        self.assertFalse(user_exists)
+        self.assertIsNone(self.customer.user_id)
 
     def assert_anonymized_order_gdpr_fields(self, order):
         self.assertEqual(order.address_text, "")

--- a/parking_permits/tests/models/test_customer.py
+++ b/parking_permits/tests/models/test_customer.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
 from decimal import Decimal
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -10,15 +11,19 @@ from freezegun import freeze_time
 
 from parking_permits.exceptions import CustomerCannotBeAnonymizedError
 from parking_permits.models.company import Company
+from parking_permits.models.customer import Customer
 from parking_permits.models.driving_class import DrivingClass
 from parking_permits.models.driving_licence import DrivingLicence
-from parking_permits.models.order import SubscriptionStatus
+from parking_permits.models.order import Order, SubscriptionStatus
 from parking_permits.models.parking_permit import (
     ContractType,
+    ParkingPermit,
+    ParkingPermitEvent,
     ParkingPermitEventFactory,
     ParkingPermitStatus,
 )
 from parking_permits.models.product import Accounting
+from parking_permits.models.refund import Refund
 from parking_permits.models.vehicle import VehicleUser
 from parking_permits.tests.factories.address import AddressFactory
 from parking_permits.tests.factories.announcement import AnnouncementFactory
@@ -1130,3 +1135,185 @@ class AnonymizeNullSsnTestCase(TestCase):
         )
         customer.refresh_from_db()
         self.assertEqual(customer.national_id_number, f"XX-ANON-{customer.pk:06d}")
+
+
+class AnonymizeAtomicityTestCase(TestCase):
+    def snapshot_object_data(
+        self,
+        customer,
+        company,
+        permit,
+        user,
+        order,
+        order_refund,
+        permit_refund,
+        permit_event,
+        driving_licence,
+    ):
+        return {
+            "customer": {
+                "id": customer.id,
+                "first_name": customer.first_name,
+                "last_name": customer.last_name,
+                "national_id_number": customer.national_id_number,
+                "email": customer.email,
+                "phone_number": customer.phone_number,
+                "primary_address_apartment": customer.primary_address_apartment,
+                "primary_address_apartment_sv": customer.primary_address_apartment_sv,
+                "other_address_apartment": customer.other_address_apartment,
+                "other_address_apartment_sv": customer.other_address_apartment_sv,
+                "source_id": customer.source_id,
+                "is_anonymized": customer.is_anonymized,
+            },
+            "company": {
+                "id": company.id,
+                "name": company.name,
+                "business_id": company.business_id,
+            },
+            "permit": {
+                "id": permit.id,
+                "address_apartment": permit.address_apartment,
+                "address_apartment_sv": permit.address_apartment_sv,
+                "next_address_apartment": permit.next_address_apartment,
+                "next_address_apartment_sv": permit.next_address_apartment_sv,
+                "description": permit.description,
+            },
+            "user": {
+                "id": user.id,
+                "email": user.email,
+                "username": user.username,
+                "first_name": user.first_name,
+                "last_name": user.last_name,
+                "is_staff": user.is_staff,
+                "is_admin": user.is_active,
+                "date_joined": user.date_joined,
+                "uuid": str(user.uuid),
+            },
+            "order": {
+                "id": order.id,
+                "address_text": order.address_text,
+                "talpa_checkout_url": order.talpa_checkout_url,
+                "talpa_logged_in_checkout_url": order.talpa_logged_in_checkout_url,
+                "talpa_receipt_url": order.talpa_receipt_url,
+                "talpa_update_card_url": order.talpa_update_card_url,
+            },
+            "order_refund": {
+                "id": order_refund.id,
+                "name": order_refund.name,
+                "iban": order_refund.iban,
+                "description": order_refund.description,
+            },
+            "permit_refund": {
+                "id": permit_refund.id,
+                "name": permit_refund.name,
+                "iban": permit_refund.iban,
+                "description": permit_refund.description,
+            },
+            "permit_event": {
+                "id": permit_event.id,
+                "context": permit_event.context,
+            },
+            "driving_licence": {
+                "id": driving_licence.id,
+                "customer_id": driving_licence.customer_id,
+                "start_date": driving_licence.start_date,
+                "end_date": driving_licence.end_date,
+                "active": driving_licence.active,
+            },
+        }
+
+    def snapshot_object_counts(self):
+        return {
+            "customer": Customer.objects.count(),
+            "company": Company.objects.count(),
+            "permit": ParkingPermit.objects.count(),
+            "user": User.objects.count(),
+            "order": Order.objects.count(),
+            "refund": Refund.objects.count(),
+            "event": ParkingPermitEvent.objects.count(),
+            "driving_licence": DrivingLicence.objects.count(),
+        }
+
+    def test_failure_mid_anonymization_rolls_back_all_changes(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory(first_name="Original", email="real@x.fi")
+            company = Company.objects.create(
+                name="Oy Firma Ab",
+                business_id="1234567-8",
+                company_owner=customer,
+                address=AddressFactory(),
+            )
+            permit = ParkingPermitFactory(customer=customer, description="real desc")
+            user = customer.user
+            order = OrderFactory(customer=customer)
+            order_refund = RefundFactory()
+            order_refund.orders.add(order)
+            permit_refund = RefundFactory()
+            order_refund.permits.add(permit)
+            driving_licence = DrivingLicence.objects.create(
+                customer=customer,
+                start_date=date(1990, 1, 1),
+                active=True,
+            )
+            permit_event = ParkingPermitEventFactory.make_end_permit_event(
+                permit=permit
+            )
+
+        original_data = self.snapshot_object_data(
+            customer,
+            company,
+            permit,
+            user,
+            order,
+            order_refund,
+            permit_refund,
+            permit_event,
+            driving_licence,
+        )
+
+        original_counts = self.snapshot_object_counts()
+
+        # Force a failure on the very last step (clearing permit event contexts)
+        with freeze_time(timezone.make_aware(datetime(2022, 12, 31, 0, 0, 1))):
+            with patch(
+                "parking_permits.models.customer.ParkingPermitEvent.objects.filter"
+            ) as mock_filter:
+                mock_qs = mock_filter.return_value
+                mock_qs.update.side_effect = RuntimeError("boom")
+                with self.assertRaises(RuntimeError):
+                    customer.anonymize_all_data()
+
+        # Refresh data "manually", do NOT use refresh_from_db() as it can be wonky after rollbacked transactions.
+        customer = Customer.objects.get(id=original_data["customer"]["id"])
+        company = Company.objects.get(id=original_data["company"]["id"])
+        permit = ParkingPermit.objects.get(id=original_data["permit"]["id"])
+        user = User.objects.get(id=original_data["user"]["id"])
+        order = Order.objects.get(id=original_data["order"]["id"])
+        order_refund = Refund.objects.get(id=original_data["order_refund"]["id"])
+        permit_refund = Refund.objects.get(id=original_data["permit_refund"]["id"])
+        driving_licence = DrivingLicence.objects.get(
+            id=original_data["driving_licence"]["id"]
+        )
+        permit_event = ParkingPermitEvent.objects.get(
+            id=original_data["permit_event"]["id"]
+        )
+
+        new_data = self.snapshot_object_data(
+            customer,
+            company,
+            permit,
+            user,
+            order,
+            order_refund,
+            permit_refund,
+            permit_event,
+            driving_licence,
+        )
+
+        for key in original_data.keys():
+            self.assertEqual(original_data[key], new_data[key])
+
+        new_counts = self.snapshot_object_counts()
+
+        for key in original_counts.keys():
+            self.assertEqual(original_counts[key], new_counts[key])

--- a/parking_permits/tests/test_returning_user.py
+++ b/parking_permits/tests/test_returning_user.py
@@ -1,0 +1,116 @@
+from datetime import datetime
+from unittest.mock import patch
+
+import freezegun
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+from helusers.authz import UserAuthorization
+
+import parking_permits.decorators
+from audit_logger import AuditMsg
+from parking_permits.models import Customer
+from parking_permits.resolvers import resolve_user_profile
+from parking_permits.tests.factories.customer import CustomerFactory
+from parking_permits.tests.test_admin_graphql import _make_mock_info
+from users.tests.factories.user import UserFactory
+
+User = get_user_model()
+
+
+class ReturningUserAfterAnonymizationTestCase(TestCase):
+    REAL_SSN = "010101-123A"
+
+    @patch.object(parking_permits.decorators.RequestJWTAuthentication, "authenticate")
+    @patch("parking_permits.resolvers.get_addresses")
+    @patch("parking_permits.resolvers.HelsinkiProfile")
+    def test_returning_user_creates_new_customer_after_old_user_deleted(
+        self, mock_helsinki_profile, mock_get_addresses, mock_authenticate
+    ):
+        """
+        Old User was deleted during anonymization -> Customer.user is null via
+        SET_NULL. New login creates a fresh User and a fresh Customer.
+        """
+        mock_get_addresses.return_value = ({}, {})
+
+        with freezegun.freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            old_customer = CustomerFactory(national_id_number=self.REAL_SSN)
+
+        with freezegun.freeze_time(
+            timezone.make_aware(datetime(2022, 12, 31, 0, 0, 1))
+        ):
+            old_customer.anonymize_all_data()
+
+        old_customer.refresh_from_db()
+        self.assertIsNone(old_customer.user_id)
+
+        # Returning user logs in with a freshly-issued helusers User
+        new_user = UserFactory()
+        mock_helsinki_profile.return_value.get_customer.return_value = {
+            "source_system": "HELSINKI_PROFILE",
+            "source_id": "new-source",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "email": "jane@example.com",
+            "phone_number": "+358000",
+            "national_id_number": self.REAL_SSN,
+        }
+
+        mock_authenticate.return_value = UserAuthorization(new_user, {})
+        request = RequestFactory().post("/")
+        request.user = new_user
+        info = _make_mock_info(request)
+
+        new_customer = resolve_user_profile(None, info, audit_msg=AuditMsg("test"))
+
+        # A new Customer was created (the old anonymized one had XX-ANON-...)
+        self.assertEqual(
+            Customer.objects.filter(national_id_number=self.REAL_SSN).count(), 1
+        )
+
+        self.assertNotEqual(new_customer.pk, old_customer.pk)
+        self.assertEqual(new_customer.user_id, new_user.id)
+
+    @patch.object(parking_permits.decorators.RequestJWTAuthentication, "authenticate")
+    @patch("parking_permits.resolvers.get_addresses")
+    @patch("parking_permits.resolvers.HelsinkiProfile")
+    def test_returning_user_does_not_reuse_anonymized_customer(
+        self,
+        mock_helsinki_profile,
+        mock_get_addresses,
+        mock_authenticate,
+    ):
+        """The anonymized customer's SSN is XX-ANON-... so lookup by real SSN
+        must miss it and create a new record."""
+        mock_get_addresses.return_value = ({}, {})
+
+        with freezegun.freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            old_customer = CustomerFactory(national_id_number=self.REAL_SSN)
+
+        with freezegun.freeze_time(
+            timezone.make_aware(datetime(2022, 12, 31, 0, 0, 1))
+        ):
+            old_customer.anonymize_all_data()
+
+        new_user = UserFactory()
+        mock_helsinki_profile.return_value.get_customer.return_value = {
+            "source_system": "HELSINKI_PROFILE",
+            "source_id": "src",
+            "first_name": "A",
+            "last_name": "B",
+            "email": "a@b.c",
+            "phone_number": "1",
+            "national_id_number": self.REAL_SSN,
+        }
+
+        mock_authenticate.return_value = UserAuthorization(new_user, {})
+        request = RequestFactory().post("/")
+        request.user = new_user
+        info = _make_mock_info(request)
+
+        new_customer = resolve_user_profile(None, info, audit_msg=AuditMsg("test"))
+
+        old_customer.refresh_from_db()
+        self.assertNotEqual(new_customer.pk, old_customer.pk)
+        self.assertTrue(old_customer.is_anonymized)
+        self.assertFalse(new_customer.is_anonymized)

--- a/parking_permits/tests/test_returning_user.py
+++ b/parking_permits/tests/test_returning_user.py
@@ -114,3 +114,50 @@ class ReturningUserAfterAnonymizationTestCase(TestCase):
         self.assertNotEqual(new_customer.pk, old_customer.pk)
         self.assertTrue(old_customer.is_anonymized)
         self.assertFalse(new_customer.is_anonymized)
+
+    @patch.object(parking_permits.decorators.RequestJWTAuthentication, "authenticate")
+    @patch("parking_permits.resolvers.get_addresses")
+    @patch("parking_permits.resolvers.HelsinkiProfile")
+    def test_returning_user_with_identical_uuid(
+        self,
+        mock_helsinki_profile,
+        mock_get_addresses,
+        mock_authenticate,
+    ):
+        mock_get_addresses.return_value = ({}, {})
+
+        with freezegun.freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            old_customer = CustomerFactory(national_id_number=self.REAL_SSN)
+
+        with freezegun.freeze_time(
+            timezone.make_aware(datetime(2022, 12, 31, 0, 0, 1))
+        ):
+            old_uuid = old_customer.user.uuid
+            old_customer.anonymize_all_data()
+
+        old_customer.refresh_from_db()
+        self.assertIsNone(old_customer.user_id)
+
+        new_user = UserFactory(uuid=old_uuid)
+
+        mock_helsinki_profile.return_value.get_customer.return_value = {
+            "source_system": "HELSINKI_PROFILE",
+            "source_id": "src",
+            "first_name": "A",
+            "last_name": "B",
+            "email": "a@b.c",
+            "phone_number": "1",
+            "national_id_number": self.REAL_SSN,
+        }
+
+        mock_authenticate.return_value = UserAuthorization(new_user, {})
+        request = RequestFactory().post("/")
+        request.user = new_user
+        info = _make_mock_info(request)
+
+        new_customer = resolve_user_profile(None, info, audit_msg=AuditMsg("test"))
+
+        old_customer.refresh_from_db()
+        self.assertNotEqual(new_customer.pk, old_customer.pk)
+        self.assertTrue(old_customer.is_anonymized)
+        self.assertFalse(new_customer.is_anonymized)

--- a/parking_permits/tests/test_views.py
+++ b/parking_permits/tests/test_views.py
@@ -2021,22 +2021,22 @@ class ParkingPermitsGDPRAPIViewTestCase(APITestCase):
 
     def create_customer(self):
         user = UserFactory(uuid=self.CUSTOMER_USER_UUID)
-        customer = CustomerFactory(
+        self.customer = CustomerFactory(
             user=user,
             source_system=SourceSystem.HELSINKI_PROFILE,
             source_id=self.CUSTOMER_SOURCE_ID,
         )
         ParkingPermitFactory(
-            customer=customer,
+            customer=self.customer,
             status=ParkingPermitStatus.CLOSED,
             end_time=tz.localtime(datetime.datetime(2020, 2, 1, tzinfo=datetime.UTC)),
         )
-        return customer
+        return self.customer
 
     def assert_customer_anonymized(self):
         self.assertTrue(
             Customer.objects.filter(
-                user__uuid=self.CUSTOMER_USER_UUID, is_anonymized=True
+                id=self.customer.id, user_id=None, is_anonymized=True
             ).exists()
         )
         # Permit should still exist due to anonymization
@@ -2045,7 +2045,9 @@ class ParkingPermitsGDPRAPIViewTestCase(APITestCase):
     def assert_customer_not_anonymized(self):
         self.assertTrue(
             Customer.objects.filter(
-                source_id=self.CUSTOMER_SOURCE_ID, is_anonymized=False
+                id=self.customer.id,
+                source_id=self.CUSTOMER_SOURCE_ID,
+                is_anonymized=False,
             ).exists()
         )
         self.assertTrue(ParkingPermit.objects.exists())


### PR DESCRIPTION
## Description

Remove a customer's user upon anonymization instead of
anonymizing the fields on the user-object.

## Context

Anonymized customers retain their possible linked user, causing
`resolve_user_profile()` to fail on returning users due to an attempt
to create another `Customer`-instance referencing the same user. This
violates `OneToOne`-constraint and raises an `IntegrityError`. Affected 
end-users see this as an "internal error" upon login while being unable
to proceed further.

## How Has This Been Tested?

Unit tests.