### PR TITLE
SHPPWS-249: do not inherit secrets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   common:
     uses: City-of-Helsinki/.github/.github/workflows/ci-django-api.yml@main
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     with:
       python-version: 3.12
       postgres-major-version: 17


### PR DESCRIPTION

## Description

List secret names explicitly in the github CI-configuration file over using the 'inherit'-instruction. The values of the secrets are still read from the CI-secrets.

## Context

Sonarcloud raised using the 'inherit'-instruction  for handling secrets as an issue.

## How Has This Been Tested?

Checked sonarcloud and that the updated pipeline passes.