### PR TITLE
SHPPWS-238: null temporary vehicle user-link when deleting user

### DIFF
--- a/parking_permits/models/customer.py
+++ b/parking_permits/models/customer.py
@@ -15,6 +15,7 @@ from helsinki_gdpr.models import SerializableMixin
 from parking_permits.exceptions import CustomerCannotBeAnonymizedError
 from parking_permits.models.announcement import Announcement
 from parking_permits.models.product import Accounting, Product
+from parking_permits.models.temporary_vehicle import TemporaryVehicle
 
 from ..services.traficom import Traficom
 from .common import SourceSystem
@@ -440,6 +441,9 @@ class Customer(SerializableMixin, TimestampedModelMixin):
                 )
 
                 Refund.objects.filter(accepted_by=self.user).update(accepted_by=None)
+                TemporaryVehicle.objects.filter(created_by=self.user).update(
+                    created_by=None
+                )
 
                 for model_class in models_with_protected_user_reference:
                     model_class.objects.filter(created_by=self.user).update(

--- a/parking_permits/tests/models/test_customer.py
+++ b/parking_permits/tests/models/test_customer.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+from dateutil.relativedelta import relativedelta
 from django.contrib.auth import get_user_model
 from django.db.models import ProtectedError
 from django.test import TestCase
@@ -24,6 +25,7 @@ from parking_permits.models.parking_permit import (
 )
 from parking_permits.models.product import Accounting
 from parking_permits.models.refund import Refund
+from parking_permits.models.temporary_vehicle import TemporaryVehicle
 from parking_permits.models.vehicle import VehicleUser
 from parking_permits.tests.factories.address import AddressFactory
 from parking_permits.tests.factories.announcement import AnnouncementFactory
@@ -939,6 +941,23 @@ class AnonymizeUserDeletionProtectionTestCase(TestCase):
             user=user, related_object=announcement, user_link_field="modified_by"
         )
 
+    def test_user_with_created_temporary_vehicle_can_still_be_anonymized_and_deleted(
+        self,
+    ):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            temporary_vehicle = TemporaryVehicle.objects.create(
+                vehicle=VehicleFactory(),
+                end_time=timezone.now() + relativedelta(days=1),
+            )
+            temporary_vehicle.created_by = user
+            temporary_vehicle.save()
+
+        self.user_can_still_be_anonymized_and_deleted_helper(
+            user=user, related_object=temporary_vehicle, user_link_field="created_by"
+        )
+
     def test_user_with_created_permit_event_blocks_naive_delete(self):
         with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
             customer = CustomerFactory()
@@ -1102,6 +1121,20 @@ class AnonymizeUserDeletionProtectionTestCase(TestCase):
             accounting = Accounting.objects.create()
             accounting.modified_by = user
             accounting.save()
+
+        with self.assertRaises(ProtectedError):
+            user.delete()
+
+    def test_user_with_created_temporary_vehicle_blocks_naive_delete(self):
+        with freeze_time(timezone.make_aware(datetime(2020, 1, 1))):
+            customer = CustomerFactory()
+            user = customer.user
+            temporary_vehicle = TemporaryVehicle.objects.create(
+                vehicle=VehicleFactory(),
+                end_time=timezone.now() + relativedelta(days=1),
+            )
+            temporary_vehicle.created_by = user
+            temporary_vehicle.save()
 
         with self.assertRaises(ProtectedError):
             user.delete()


### PR DESCRIPTION
## Description

Deleting an user during anonymization may fail due to protected-constraint in created_by-field in the TemporaryVehicle-model. Fix this by nulling the created_by-field before deleting the user.

## Context

Implementing this fix was missed [when fixing other similar user links](https://github.com/City-of-Helsinki/parking-permits/commit/160346ba1ac39ea18da24ecdf543c5509ef23b56).

## How Has This Been Tested?

Unit tests