### PR TITLE
fix: add Content-Type header to DVV-queries

### DIFF
--- a/parking_permits/services/dvv.py
+++ b/parking_permits/services/dvv.py
@@ -49,7 +49,10 @@ def get_auth_token():
 
 def get_request_headers():
     token = get_auth_token()
-    return {"Authorization": f"Basic {token}"}
+    return {
+        "Authorization": f"Basic {token}",
+        "Content-Type": "application/json",
+    }
 
 
 def get_request_data(hetu):

--- a/parking_permits/tests/services/test_dvv.py
+++ b/parking_permits/tests/services/test_dvv.py
@@ -102,6 +102,25 @@ class GetPersonInfoTestCase(TestCase):
         self.assertEqual(customer["primary_address"]["city"], "Helsinki")
         self.assertEqual(customer["primary_address_apartment"], "A6")
 
+    @patch("parking_permits.services.dvv.get_address_details")
+    @patch("requests.post")
+    def test_get_customer_info_with_empty_address_data(
+        self, mock_post, mock_get_address_details
+    ):
+        mock_post.return_value = self.MockResponse(
+            data=self.get_mock_info_empty_addresses()
+        )
+        mock_get_address_details.side_effect = AssertionError(
+            "get_address_details should not be called for empty address data"
+        )
+        customer = get_person_info("12345")
+        self.assertEqual(customer["first_name"], "Ossi")
+        self.assertEqual(customer["last_name"], "Oksanen")
+        self.assertEqual(customer["primary_address"], None)
+        self.assertEqual(customer["primary_address_apartment"], "")
+        self.assertEqual(customer["other_address"], None)
+        self.assertEqual(customer["other_address_apartment"], "")
+
     def get_mock_info(self, **kwargs):
         return {
             "Henkilo": {
@@ -120,6 +139,29 @@ class GetPersonInfoTestCase(TestCase):
                     "LahiosoiteR": "Handkrem 6 B7",
                     "PostitoimipaikkaR": "Helsingfors",
                     "Postinumero": "10001",
+                },
+            },
+            **kwargs,
+        }
+
+    def get_mock_info_empty_addresses(self, **kwargs):
+        return {
+            "Henkilo": {
+                "NykyinenSukunimi": {"Sukunimi": "Oksanen"},
+                "NykyisetEtunimet": {"Etunimet": "Ossi"},
+                "VakinainenKotimainenLahiosoite": {
+                    "LahiosoiteS": "",
+                    "PostitoimipaikkaS": "",
+                    "LahiosoiteR": "",
+                    "PostitoimipaikkaR": "",
+                    "Postinumero": "",
+                },
+                "TilapainenKotimainenLahiosoite": {
+                    "LahiosoiteS": "",
+                    "PostitoimipaikkaS": "",
+                    "LahiosoiteR": "",
+                    "PostitoimipaikkaR": "",
+                    "Postinumero": "",
                 },
             },
             **kwargs,


### PR DESCRIPTION
Add explicit "Content-Type": "application/json"-header to DVV-queries to allow better compatibility with the new VTJ-integration.

Also add test for empty addresses which format is slightly changed in the new VTJ-integration (previously empty default values were null, now they are empty strings).

Refs: SHPPWS-227
