### PR TITLE
SHPPWS-264: cap secondary permit end date correctly

### DIFF
--- a/parking_permits/customer_permit.py
+++ b/parking_permits/customer_permit.py
@@ -313,7 +313,7 @@ class CustomerPermit:
             contract_type = data.get("contract_type", None)
             month_count = data.get("month_count", 1)
             primary, secondary = self._get_primary_and_secondary_permit()
-            end_time = get_end_time(primary.start_time, month_count)
+            primary_end_time = get_end_time(primary.start_time, month_count)
 
             if not contract_type:
                 raise InvalidContractTypeError(_("Contract type is required"))
@@ -348,8 +348,24 @@ class CustomerPermit:
                     month_count = self._get_month_count_for_secondary_permit(
                         contract_type, month_count
                     )
-                    sec_p_end_time = get_end_time(secondary.start_time, month_count)
-                    end_time = end_time if sec_p_end_time > end_time else sec_p_end_time
+                    secondary_permit_end_time = get_end_time(
+                        secondary.start_time, month_count
+                    )
+
+            end_time = primary_end_time
+            if permit_id and not is_primary:
+                # Cap the end date to the primary permit's end date if it is
+                # earlier than the secondary permit's calculated end date.
+                # Using get_end_time() here is more in line with the pre-bugfix
+                # logic and ensures that we do not have any trouble with any
+                # possible null end dates on the primary permit. Note that
+                # month_count is the form-inputed month count that is used to
+                # calculate the secondary permit's end time and is not
+                # necessarily equal to primary.month_count.
+                secondary_permit_max_end_time = get_end_time(
+                    primary.start_time, primary.month_count
+                )
+                end_time = min(secondary_permit_end_time, secondary_permit_max_end_time)
 
             fields_to_update.update(
                 {

--- a/parking_permits/tests/test_customer_permit.py
+++ b/parking_permits/tests/test_customer_permit.py
@@ -37,6 +37,7 @@ from parking_permits.tests.factories.vehicle import (
     VehicleFactory,
     VehiclePowerTypeFactory,
 )
+from parking_permits.utils import get_end_time as get_permit_end_time
 
 DRAFT = ParkingPermitStatus.DRAFT
 VALID = ParkingPermitStatus.VALID
@@ -585,10 +586,19 @@ class UpdateCustomerPermitTestCase(TestCase):
         self,
     ):
         customer = CustomerFactory(first_name="Fake", last_name="")
-        ParkingPermitFactory(customer=customer, status=VALID)
+        primary_start_time = next_day()
+        ParkingPermitFactory(
+            customer=customer,
+            status=VALID,
+            start_time=primary_start_time,
+            end_time=get_end_time(primary_start_time, 12),
+        )
+        secondary_start_time = next_day()
         secondary = ParkingPermitFactory(
             customer=customer,
             primary_vehicle=False,
+            start_time=secondary_start_time,
+            end_time=get_end_time(secondary_start_time, 12),
         )
         permit_id = str(secondary.id)
         data = {"contract_type": OPEN_ENDED}
@@ -603,11 +613,21 @@ class UpdateCustomerPermitTestCase(TestCase):
 
     def test_secondary_permit_can_be_only_fixed_if_primary_is_fixed_period(self):
         customer = CustomerFactory(first_name="Customer 1", last_name="")
+        primary_start_time = next_day()
         ParkingPermitFactory(
-            customer=customer, status=VALID, contract_type=FIXED_PERIOD
+            customer=customer,
+            status=VALID,
+            contract_type=FIXED_PERIOD,
+            start_time=primary_start_time,
+            end_time=get_end_time(primary_start_time, 12),
         )
+        secondary_start_time = next_day()
         secondary = ParkingPermitFactory(
-            customer=customer, primary_vehicle=False, contract_type=FIXED_PERIOD
+            customer=customer,
+            primary_vehicle=False,
+            contract_type=FIXED_PERIOD,
+            start_time=secondary_start_time,
+            end_time=get_end_time(secondary_start_time, 12),
         )
 
         permit_id = str(secondary.id)
@@ -656,8 +676,19 @@ class UpdateCustomerPermitTestCase(TestCase):
 
     def test_second_permit_can_have_upto_12_month_if_primary_is_open_ended(self):
         customer = CustomerFactory()
-        ParkingPermitFactory(customer=customer)
-        secondary = ParkingPermitFactory(customer=customer, primary_vehicle=False)
+        primary_start_time = next_day()
+        ParkingPermitFactory(
+            customer=customer,
+            start_time=primary_start_time,
+            end_time=get_end_time(primary_start_time, 12),
+        )
+        secondary_start_time = next_day()
+        secondary = ParkingPermitFactory(
+            customer=customer,
+            primary_vehicle=False,
+            start_time=secondary_start_time,
+            end_time=get_end_time(secondary_start_time, 12),
+        )
         data = {"month_count": 12, "contract_type": FIXED_PERIOD}
         permit_id = str(secondary.id)
         CustomerPermit(customer.id).update(data, permit_id=permit_id)
@@ -683,6 +714,44 @@ class UpdateCustomerPermitTestCase(TestCase):
         CustomerPermit(customer.id).update(data, permit_id=permit_id)
         secondary.refresh_from_db()
         self.assertEqual(secondary.month_count, 5)
+
+    @freeze_time(tz.make_aware(datetime(2026, 7, 11)))
+    def test_secondary_permit_end_time_is_based_on_its_own_start_time(self):
+        # A secondary fixed-period permit bought partway through the
+        # primary's period must end based on its own start time (capped by the
+        # primary's end time), not capped by the primary permit's start time
+        # + the month count of the secondary permit.
+        customer = CustomerFactory(first_name="Regression", last_name="")
+
+        primary_start = tz.make_aware(datetime(2026, 6, 18))
+        primary_end = get_permit_end_time(primary_start, 3)  # 17.9.2026 23:59
+        ParkingPermitFactory(
+            customer=customer,
+            status=VALID,
+            primary_vehicle=True,
+            contract_type=FIXED_PERIOD,
+            month_count=3,
+            start_time=primary_start,
+            end_time=primary_end,
+        )
+
+        secondary_start = tz.make_aware(datetime(2026, 7, 13))
+        secondary = ParkingPermitFactory(
+            customer=customer,
+            status=DRAFT,
+            primary_vehicle=False,
+            contract_type=FIXED_PERIOD,
+            start_time=secondary_start,
+        )
+
+        data = {"month_count": 2, "contract_type": FIXED_PERIOD}
+        CustomerPermit(customer.id).update(data, permit_id=str(secondary.id))
+
+        secondary.refresh_from_db()
+
+        expected_end_time = get_permit_end_time(secondary_start, 2)  # 12.9.2026 23:59
+        self.assertEqual(secondary.month_count, 2)
+        self.assertEqual(secondary.end_time, expected_end_time)
 
 
 class ExtendCustomerPermitTestCase(TestCase):


### PR DESCRIPTION
## Description

Fix the logic that caps the end date of the secondary permit to use the end time of the primary permit instead of start time of the primary permit added with the month count from the input form. The old logic constrains the end date too much if the secondary permit has smaller month count than the primary permit.

## Context

It was noted that purchased secondary permits may receive erroneous end dates when purchased with smaller month count than the primary permit has.

## How Has This Been Tested?

Unit tests. The added test has been verified to fail before implementing the fix.
