### PR TITLE
SHPPWS-265: management command for counting permits that were valid on given date(s)

### DIFF
--- a/parking_permits/management/commands/count_valid_permits_on_date.py
+++ b/parking_permits/management/commands/count_valid_permits_on_date.py
@@ -1,0 +1,121 @@
+import datetime
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+from django.utils import timezone
+
+from parking_permits.models.parking_permit import ParkingPermit, ParkingPermitStatus
+
+
+def _range_bounds(start_date, end_date):
+    current_timezone = timezone.get_current_timezone()
+    range_start = timezone.make_aware(
+        datetime.datetime.combine(start_date, datetime.time.min), current_timezone
+    )
+    range_end = timezone.make_aware(
+        datetime.datetime.combine(end_date, datetime.time.max), current_timezone
+    )
+    return range_start, range_end
+
+
+def count_valid_permits(start_date, end_date=None, *, include_unpaid_cancelled=False):
+    """Best-effort count of permits that were valid on any date in the given
+    inclusive range. With a single date, counts permits valid on that date.
+
+    There is no historical status log, so validity is inferred from the
+    permits' current status together with their start/end times and, for
+    cancelled permits, whether they were ever actually paid.
+    """
+    if end_date is None:
+        end_date = start_date
+
+    range_start, range_end = _range_bounds(start_date, end_date)
+
+    # Currently VALID permits that started on or before the end of the range
+    # and whose (historically optional) end_time overlaps the range. If a
+    # permit is still marked VALID but has an end_time before range_start
+    # (e.g., expiration job missed), it would be incorrectly counted for
+    # historical periods.
+    valid_permits = ParkingPermit.objects.filter(
+        status=ParkingPermitStatus.VALID,
+        start_time__lte=range_end,
+    ).filter(Q(end_time__isnull=True) | Q(end_time__gte=range_start))
+
+    # Permits that have since been CLOSED or CANCELLED but whose validity
+    # window [start_time, end_time] overlaps the range.
+    ended_permits = ParkingPermit.objects.filter(
+        status__in=(ParkingPermitStatus.CLOSED, ParkingPermitStatus.CANCELLED),
+        start_time__lte=range_end,
+    ).filter(Q(end_time__isnull=True) | Q(end_time__gte=range_start))
+
+    if not include_unpaid_cancelled:
+        # A genuinely valid-then-cancelled permit always has at least one order
+        # that was paid on or before the end of the range. `paid_time` is set
+        # when an order is confirmed/paid and is never cleared, so it stays
+        # reliable even when the order is later moved to CANCELLED on ending or
+        # refund. Timed-out purchases never receive a `paid_time`.
+        ended_permits = ended_permits.filter(
+            Q(status=ParkingPermitStatus.CLOSED)
+            | Q(
+                status=ParkingPermitStatus.CANCELLED,
+                orders__paid_time__isnull=False,
+                orders__paid_time__lte=range_end,
+            )
+        )
+
+    # Note that the two querysets filter for different statuses, so
+    # there is no risk of overlap and we can just add the counts
+    # without worrying about double-counting.
+    return valid_permits.distinct("id").count() + ended_permits.distinct("id").count()
+
+
+class Command(BaseCommand):
+    help = (
+        "Calculate a best-effort count of parking permits that were valid on a "
+        "given past date, or on any date within an inclusive date range. "
+        "Intended for dates that predate the daily permit count snapshots."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "start_date",
+            type=datetime.date.fromisoformat,
+            help="Date (or range start) in ISO format (YYYY-MM-DD).",
+        )
+        parser.add_argument(
+            "end_date",
+            type=datetime.date.fromisoformat,
+            nargs="?",
+            help="Optional inclusive range end in ISO format (YYYY-MM-DD).",
+        )
+        parser.add_argument(
+            "--include-unpaid-cancelled",
+            action="store_true",
+            help=(
+                "Include CANCELLED permits that were never paid for. These are "
+                "excluded by default, since they are most likely purchases that "
+                "timed out and were never actually valid."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        start_date = options["start_date"]
+        end_date = options["end_date"] or start_date
+
+        if end_date < start_date:
+            raise CommandError("end_date must not be earlier than start_date.")
+
+        total = count_valid_permits(
+            start_date,
+            end_date,
+            include_unpaid_cancelled=options["include_unpaid_cancelled"],
+        )
+
+        if start_date == end_date:
+            period = start_date.isoformat()
+        else:
+            period = f"{start_date.isoformat()}..{end_date.isoformat()}"
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Best-effort valid permit count for {period}: {total}")
+        )

--- a/parking_permits/tests/commands/test_count_valid_permits_on_date.py
+++ b/parking_permits/tests/commands/test_count_valid_permits_on_date.py
@@ -1,0 +1,325 @@
+import datetime
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.utils import timezone
+
+from parking_permits.management.commands.count_valid_permits_on_date import (
+    count_valid_permits,
+)
+from parking_permits.models.order import OrderStatus
+from parking_permits.models.parking_permit import ParkingPermitStatus
+from parking_permits.tests.factories.order import OrderFactory
+from parking_permits.tests.factories.parking_permit import ParkingPermitFactory
+
+SAMPLE_DATE = datetime.date(2024, 1, 15)
+RANGE_START = datetime.date(2024, 1, 10)
+RANGE_END = datetime.date(2024, 1, 20)
+
+
+def _aware(year, month, day, hour=12):
+    return timezone.make_aware(datetime.datetime(year, month, day, hour))
+
+
+# --- Single date ---------------------------------------------------------
+
+
+@pytest.mark.django_db()
+def test_valid_permit_started_before_date_is_counted():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.VALID,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 6, 1),
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 1
+
+
+@pytest.mark.django_db()
+def test_valid_permit_started_on_date_is_counted():
+    # Any time on the sample date is accepted.
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.VALID,
+        start_time=_aware(2024, 1, 15, hour=23),
+        end_time=_aware(2024, 6, 15),
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 1
+
+
+@pytest.mark.django_db()
+def test_valid_permit_started_after_sample_date_is_not_counted():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.VALID,
+        start_time=_aware(2024, 1, 16),
+        end_time=_aware(2024, 6, 16),
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 0
+
+
+@pytest.mark.django_db()
+def test_valid_permit_ended_before_sample_date_is_not_counted():
+    # Guards against a permit still marked VALID (e.g., missed expiration job)
+    # whose end_time is before the sample date being counted for that date.
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.VALID,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 1, 10),
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 0
+
+
+@pytest.mark.django_db()
+def test_closed_permit_covering_sample_date_is_counted():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CLOSED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 1
+
+
+@pytest.mark.django_db()
+def test_closed_permit_ended_before_sample_date_is_not_counted():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CLOSED,
+        start_time=_aware(2023, 12, 1),
+        end_time=_aware(2024, 1, 10),
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 0
+
+
+@pytest.mark.django_db()
+def test_closed_permit_started_after_sample_date_is_not_counted():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CLOSED,
+        start_time=_aware(2024, 1, 20),
+        end_time=_aware(2024, 3, 1),
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 0
+
+
+@pytest.mark.django_db()
+def test_cancelled_permit_with_paid_order_is_counted():
+    order = OrderFactory(status=OrderStatus.CONFIRMED, paid_time=_aware(2024, 1, 10))
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CANCELLED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+        orders=[order],
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 1
+
+
+@pytest.mark.django_db()
+def test_cancelled_permit_paid_then_order_cancelled_is_still_counted():
+    # Regression guard: ending/refunding flips the paid order to CANCELLED but
+    # keeps paid_time, so the permit must still count.
+    order = OrderFactory(status=OrderStatus.CANCELLED, paid_time=_aware(2024, 1, 10))
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CANCELLED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+        orders=[order],
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 1
+
+
+@pytest.mark.django_db()
+def test_cancelled_permit_never_paid_is_not_counted_by_default():
+    order = OrderFactory(status=OrderStatus.CANCELLED, paid_time=None)
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CANCELLED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+        orders=[order],
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 0
+
+
+@pytest.mark.django_db()
+def test_cancelled_permit_never_paid_is_counted_when_flag_set():
+    order = OrderFactory(status=OrderStatus.CANCELLED, paid_time=None)
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CANCELLED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+        orders=[order],
+    )
+    assert count_valid_permits(SAMPLE_DATE, include_unpaid_cancelled=True) == 1
+
+
+@pytest.mark.django_db()
+def test_cancelled_permit_paid_after_date_is_not_counted():
+    order = OrderFactory(status=OrderStatus.CONFIRMED, paid_time=_aware(2024, 1, 20))
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CANCELLED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+        orders=[order],
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 0
+
+
+@pytest.mark.django_db()
+def test_cancelled_permit_with_multiple_paid_orders_counted_once():
+    first_order = OrderFactory(
+        status=OrderStatus.CONFIRMED, paid_time=_aware(2024, 1, 5)
+    )
+    second_order = OrderFactory(
+        status=OrderStatus.CANCELLED, paid_time=_aware(2024, 1, 8)
+    )
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CANCELLED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+        orders=[first_order, second_order],
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 1
+
+
+@pytest.mark.django_db()
+def test_draft_and_payment_in_progress_permits_are_ignored():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.DRAFT, start_time=_aware(2024, 1, 1)
+    )
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.PAYMENT_IN_PROGRESS, start_time=_aware(2024, 1, 1)
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 0
+
+
+@pytest.mark.django_db()
+def test_mixed_population_total():
+    # Counted: VALID and started before the sample date.
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.VALID,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 6, 1),
+    )
+    # Counted: CLOSED but its validity window covers the sample date.
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CLOSED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+    )
+    # Counted: CANCELLED but was actually paid, so it was genuinely valid.
+    paid_order = OrderFactory(
+        status=OrderStatus.CANCELLED, paid_time=_aware(2024, 1, 10)
+    )
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CANCELLED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+        orders=[paid_order],
+    )
+    # Not counted: CANCELLED and never paid (timed-out purchase).
+    unpaid_order = OrderFactory(status=OrderStatus.CANCELLED, paid_time=None)
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CANCELLED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 2, 1),
+        orders=[unpaid_order],
+    )
+    assert count_valid_permits(SAMPLE_DATE) == 3
+
+
+# --- Date range ----------------------------------------------------------
+
+
+@pytest.mark.django_db()
+def test_range_counts_permit_valid_only_at_range_start():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CLOSED,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 1, 10, hour=6),
+    )
+    assert count_valid_permits(RANGE_START, RANGE_END) == 1
+
+
+@pytest.mark.django_db()
+def test_range_counts_permit_valid_only_at_range_end():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CLOSED,
+        start_time=_aware(2024, 1, 20, hour=18),
+        end_time=_aware(2024, 2, 1),
+    )
+    assert count_valid_permits(RANGE_START, RANGE_END) == 1
+
+
+@pytest.mark.django_db()
+def test_range_ignores_permit_ended_before_range():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CLOSED,
+        start_time=_aware(2023, 12, 1),
+        end_time=_aware(2024, 1, 9),
+    )
+    assert count_valid_permits(RANGE_START, RANGE_END) == 0
+
+
+@pytest.mark.django_db()
+def test_range_ignores_permit_started_after_range():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CLOSED,
+        start_time=_aware(2024, 1, 21),
+        end_time=_aware(2024, 2, 1),
+    )
+    assert count_valid_permits(RANGE_START, RANGE_END) == 0
+
+
+@pytest.mark.django_db()
+def test_range_counts_permit_spanning_whole_range_once():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.VALID,
+        start_time=_aware(2023, 12, 1),
+        end_time=_aware(2024, 6, 1),
+    )
+    assert count_valid_permits(RANGE_START, RANGE_END) == 1
+
+
+@pytest.mark.django_db()
+def test_range_excludes_never_paid_cancelled_by_default():
+    order = OrderFactory(status=OrderStatus.CANCELLED, paid_time=None)
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.CANCELLED,
+        start_time=_aware(2024, 1, 12),
+        end_time=_aware(2024, 1, 18),
+        orders=[order],
+    )
+    assert count_valid_permits(RANGE_START, RANGE_END) == 0
+
+
+# --- Command interface ---------------------------------------------------
+
+
+@pytest.mark.django_db()
+def test_command_prints_total_for_single_date():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.VALID,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 6, 1),
+    )
+    out = StringIO()
+    call_command("count_valid_permits_on_date", "2024-01-15", stdout=out)
+    output = out.getvalue().strip()
+    assert output == "Best-effort valid permit count for 2024-01-15: 1"
+
+
+@pytest.mark.django_db()
+def test_command_prints_total_for_range():
+    ParkingPermitFactory(
+        status=ParkingPermitStatus.VALID,
+        start_time=_aware(2024, 1, 1),
+        end_time=_aware(2024, 6, 1),
+    )
+    out = StringIO()
+    call_command("count_valid_permits_on_date", "2024-01-10", "2024-01-20", stdout=out)
+    output = out.getvalue().strip()
+    assert output == "Best-effort valid permit count for 2024-01-10..2024-01-20: 1"
+
+
+@pytest.mark.django_db()
+def test_command_raises_on_end_before_start():
+    with pytest.raises(CommandError) as exc_info:
+        call_command("count_valid_permits_on_date", "2024-01-20", "2024-01-10")
+    assert str(exc_info.value) == "end_date must not be earlier than start_date."


### PR DESCRIPTION

## Description

Implement a management command for counting permits that were valid on a given date or on at least one day during a given date range.

## Context

There was an information request for the count of permits that were valid on a certain past date for which there is no permit count snapshot-data available. Similar requests have also been made earlier in the past.

## How Has This Been Tested?

Unit tests.