### PR TITLE
SHPPWS-192: fix "can extend permit"-check

### DIFF
--- a/parking_permits/models/parking_permit.py
+++ b/parking_permits/models/parking_permit.py
@@ -633,6 +633,11 @@ class ParkingPermit(SerializableMixin, TimestampedModelMixin):
         if self.has_address_changed:
             return False
 
+        # Prevent extension of permits that have been set to end after
+        # the current period but have yet to end.
+        if self.end_type == ParkingPermitEndType.AFTER_CURRENT_PERIOD:
+            return False
+
         if is_date_restriction and timezone.localdate(
             self.end_time
         ) > timezone.localdate(timezone.now() + relativedelta(days=14)):

--- a/parking_permits/tests/models/test_parking_permit.py
+++ b/parking_permits/tests/models/test_parking_permit.py
@@ -1241,6 +1241,25 @@ class ParkingPermitTestCase(TestCase):
         self.assertTrue(permit.can_extend_permit)
 
     @override_settings(PERMIT_EXTENSIONS_ENABLED=True)
+    def test_can_extend_permit_false_after_manual_end(self):
+        """Test can_extend_permit property returns False for manually ended permits."""
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.FIXED_PERIOD,
+            start_time=timezone.now() - timedelta(days=20),
+            end_time=timezone.now() + timedelta(days=9),
+        )
+        permit.address = permit.customer.primary_address
+        permit.save()
+        # Initially can extend (within 14 days)
+        self.assertTrue(permit.can_extend_permit)
+        # Manually end permit after current period
+        permit.end_permit(ParkingPermitEndType.AFTER_CURRENT_PERIOD)
+        # Should no longer be extendable
+        self.assertFalse(permit.can_extend_permit)
+        self.assertFalse(permit.can_admin_extend_permit)
+
+    @override_settings(PERMIT_EXTENSIONS_ENABLED=True)
     def test_can_extend_permit_existing_other_request(self):
         permit = ParkingPermitFactory(
             status=ParkingPermitStatus.VALID,

--- a/parking_permits/tests/test_customer_permit.py
+++ b/parking_permits/tests/test_customer_permit.py
@@ -1,6 +1,7 @@
 from datetime import UTC, date, datetime, timedelta
 from unittest.mock import MagicMock
 
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase, override_settings
@@ -20,6 +21,7 @@ from parking_permits.exceptions import (
 from parking_permits.models.parking_permit import (
     ContractType,
     ParkingPermit,
+    ParkingPermitEndType,
     ParkingPermitStartType,
     ParkingPermitStatus,
 )
@@ -817,4 +819,61 @@ class ExtendCustomerPermitTestCase(TestCase):
             permit.pk,
             3,
         )
+        self.assertFalse(permit.get_pending_extension_requests().exists())
+
+    @pytest.mark.xfail(
+        reason="Bug: permits ended after current period can still be extended"
+    )
+    @override_settings(PERMIT_EXTENSIONS_ENABLED=True)
+    def test_cannot_extend_permit_ended_after_current_period(self):
+        """Test that a permit manually ended after current period cannot be extended.
+        This is a regression test for a bug where permits ended after current period
+        could still be extended, which is not the intended behavior.
+        """
+        now = tz.now()
+        # Create permit ending in 10 days (within 14-day extension window)
+        permit = ParkingPermitFactory(
+            status=ParkingPermitStatus.VALID,
+            contract_type=ContractType.FIXED_PERIOD,
+            start_time=now - timedelta(days=20),
+            end_time=now + timedelta(days=10),
+        )
+        permit.address = permit.customer.primary_address
+        permit.save()
+        ProductFactory(
+            zone=permit.parking_zone,
+            type=ProductType.RESIDENT,
+            start_date=(now - timedelta(days=360)).date(),
+            end_date=(now + timedelta(days=360)).date(),
+        )
+        # Verify permit CAN be extended initially (within 14 days)
+        self.assertTrue(permit.can_extend_permit)
+        # Customer manually ends the permit after current period
+        CustomerPermit(permit.customer_id).end(
+            [permit.id],
+            ParkingPermitEndType.AFTER_CURRENT_PERIOD,
+            iban="FI1234567890123456",
+        )
+        # Refresh permit from database
+        permit.refresh_from_db()
+        # Verify permit status is still VALID (not CLOSED)
+        self.assertEqual(permit.status, ParkingPermitStatus.VALID)
+        # Verify end_type is set to AFTER_CURRENT_PERIOD
+        self.assertEqual(permit.end_type, ParkingPermitEndType.AFTER_CURRENT_PERIOD)
+        # Verify end_time is still set (to current_period_end_time)
+        self.assertIsNotNone(permit.end_time)
+        self.assertEqual(
+            permit.end_time, get_permit_end_time(permit.start_time, permit.month_count)
+        )
+        # BUG: Current implementation returns True (can extend)
+        # FIX: After fix, should return False (cannot extend)
+        self.assertFalse(permit.can_extend_permit)
+        # Verify exception is raised when trying to create extension request
+        with self.assertRaises(PermitCanNotBeExtendedError) as context:
+            CustomerPermit(permit.customer_id).create_permit_extension_request(
+                permit.pk,
+                3,
+            )
+        self.assertIn("cannot extend", str(context.exception).lower())
+        # Verify no extension request was created
         self.assertFalse(permit.get_pending_extension_requests().exists())

--- a/parking_permits/tests/test_customer_permit.py
+++ b/parking_permits/tests/test_customer_permit.py
@@ -1,7 +1,6 @@
 from datetime import UTC, date, datetime, timedelta
 from unittest.mock import MagicMock
 
-import pytest
 from dateutil.relativedelta import relativedelta
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase, override_settings
@@ -821,9 +820,6 @@ class ExtendCustomerPermitTestCase(TestCase):
         )
         self.assertFalse(permit.get_pending_extension_requests().exists())
 
-    @pytest.mark.xfail(
-        reason="Bug: permits ended after current period can still be extended"
-    )
     @override_settings(PERMIT_EXTENSIONS_ENABLED=True)
     def test_cannot_extend_permit_ended_after_current_period(self):
         """Test that a permit manually ended after current period cannot be extended.
@@ -865,8 +861,6 @@ class ExtendCustomerPermitTestCase(TestCase):
         self.assertEqual(
             permit.end_time, get_permit_end_time(permit.start_time, permit.month_count)
         )
-        # BUG: Current implementation returns True (can extend)
-        # FIX: After fix, should return False (cannot extend)
         self.assertFalse(permit.can_extend_permit)
         # Verify exception is raised when trying to create extension request
         with self.assertRaises(PermitCanNotBeExtendedError) as context:


### PR DESCRIPTION
## Description

- add a check in `_can_extend_parking_permit`-property to prevent extension
of permits that have been set to end after their current period but
have not yet ended.
- add tests verifying the bug and its fix

## Context

A bug was encountered where a permits that were set to end after their current period could be (erroneously) extended before the permit ending logic was ran.

## How Has This Been Tested?

- unit tests
- some manual testing will be done before finishing the PR